### PR TITLE
Fix govulncheck

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -21,17 +21,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+      - name: Get Go version from go.mod file
+        id: go-version
+        run: echo "version=$(go mod edit -json | jq -r .Go)" >> "${GITHUB_OUTPUT}"
       - name: Checkout Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: ${{ steps.go-version.outputs.version }}
       - name: Install govulncheck
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run govulncheck
-        run: govulncheck ./ddtrace/... ./appsec/... ./profiler/... ./internal/...
-      - name: Run govulncheck-contribs
-        run: |
-          go list -f '{{.Dir}}' ./contrib/... | while read dir ; do
-            govulncheck -C $dir .
-          done
+        run: govulncheck ./...


### PR DESCRIPTION
# What does this PR do?

Adapt govulncheck to current repository structure and make sure to use same Go version as in `go.mod`.

# Motivation

Fix build.
