### PR TITLE
Rename env variables to follow DataDog profiling naming conventions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y sudo && apt-ge
 
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
 
+ENV GOPATH=
+
 RUN useradd -ms /bin/bash build
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN adduser build sudo

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -63,11 +63,12 @@ import,github.com/opencontainers/go-digest,Apache-2.0,"Copyright 2019, 2020 OCI 
 import,github.com/opencontainers/image-spec,Apache-2.0,Copyright 2016 The Linux Foundation.
 import,github.com/opencontainers/runtime-spec/specs-go,Apache-2.0,Copyright 2015 The Linux Foundation.
 import,github.com/opencontainers/selinux,Apache-2.0,unknown
-import,github.com/peterbourgon/ff/v3,Apache-2.0,unknown
 import,github.com/pkg/errors,BSD-2-Clause,"Copyright (c) 2015, Dave Cheney <dave@cheney.net>"
 import,github.com/sirupsen/logrus,MIT,Copyright (c) 2014 Simon Eskildsen
 import,github.com/tklauser/numcpus,Apache-2.0,unknown
+import,github.com/urfave/cli/v3,MIT,Copyright (c) 2023 urfave/cli maintainers
 import,github.com/x448/float16,MIT,Copyright (c) 2019 Montgomery Edwards⁴⁴⁸ and Faye Amacker
+import,github.com/xrash/smetrics,MIT,Copyright (C) 2016 Felipe da Cunha Gonçalves
 import,github.com/zeebo/xxh3,BSD-2-Clause,"Copyright (c) 2012-2014, Yann Collet | Copyright (c) 2019, Jeff Wendling"
 import,go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp,Apache-2.0,unknown
 import,go.opentelemetry.io/otel,Apache-2.0,unknown

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,10 @@ licenses:
 
 check-licenses:
 	tools/check-licenses.sh
+
+docker-image:
+	docker build -t dd-otel-host-profiler -f Dockerfile .
+
+profiler-in-docker: docker-image
+	docker run -v "$$PWD":/app -it --rm --user $(shell id -u):$(shell id -g) dd-otel-host-profiler \
+	   bash -c "cd /app && make VERSION=$(VERSION)"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For compiled languages (C/C++/Rust/Go), the profiler can upload local symbols (w
 This feature requires being part of our private beta program for the OpenTelemetry profiler. Please reach out to Datadog support to get access.
 
 To enable local symbol upload:
-1. Set the `DD_EXPERIMENTAL_LOCAL_SYMBOL_UPLOAD` environment variable to `true`.
+1. Set the `DD_PROFILING_EXPERIMENTAL_UPLOAD_SYMBOLS` environment variable to `true`.
 2. Provide a Datadog API key through the `DD_API_KEY` environment variable.
 3. Set the `DD_SITE` environment variable to [your Datadog site](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site) (e.g. `datadoghq.com`, `datadoghq.eu`, `us5.datadoghq.com`, ...).
 
@@ -56,9 +56,9 @@ First, create a `.env` file with the following content:
 ARCH=amd64 # required
 DD_API_KEY=your-api-key # required
 DD_SITE=datadoghq.com # optional, defaults to "datadoghq.com"
-DD_OTEL_HOST_PROFILER_SERVICE=my-service # optional, defaults to "dd-otel-host-profiler"
-DD_OTEL_HOST_PROFILER_REPORTER_INTERVAL=10s # optional, defaults to 60s
-DD_EXPERIMENTAL_LOCAL_SYMBOL_UPLOAD=true # optional, defaults to false
+DD_SERVICE=my-service # optional, defaults to "dd-otel-host-profiler"
+DD_PROFILING_UPLOAD_PERIOD=10s # optional, defaults to 60s
+DD_PROFILING_EXPERIMENTAL_UPLOAD_SYMBOLS=true # optional, defaults to false
 ```
 
 Then, you can run the profiler with the following command:

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ For compiled languages (C/C++/Rust/Go), the profiler can upload local symbols (w
 This feature requires being part of our private beta program for the OpenTelemetry profiler. Please reach out to Datadog support to get access.
 
 To enable local symbol upload:
-1. Set the `DD_PROFILING_EXPERIMENTAL_UPLOAD_SYMBOLS` environment variable to `true`.
+1. Set the `DD_HOST_PROFILING_EXPERIMENTAL_UPLOAD_SYMBOLS` environment variable to `true`.
 2. Provide a Datadog API key through the `DD_API_KEY` environment variable.
-3. Set the `DD_SITE` environment variable to [your Datadog site](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site) (e.g. `datadoghq.com`, `datadoghq.eu`, `us5.datadoghq.com`, ...).
+3. Provide a Datadog APP key through the `DD_APP_KEY` environment variable.
+4. Set the `DD_SITE` environment variable to [your Datadog site](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site) (e.g. `datadoghq.com`, `datadoghq.eu`, `us5.datadoghq.com`, ...).
 
 ## Development
 
@@ -53,12 +54,12 @@ A `docker-compose.yml` file is provided to help run the profiler in a container 
 First, create a `.env` file with the following content:
 
 ```
-ARCH=amd64 # required
 DD_API_KEY=your-api-key # required
+DD_APP_KEY=your-app-key # required
 DD_SITE=datadoghq.com # optional, defaults to "datadoghq.com"
 DD_SERVICE=my-service # optional, defaults to "dd-otel-host-profiler"
-DD_PROFILING_UPLOAD_PERIOD=10s # optional, defaults to 60s
-DD_PROFILING_EXPERIMENTAL_UPLOAD_SYMBOLS=true # optional, defaults to false
+DD_HOST_PROFILING_UPLOAD_PERIOD=10s # optional, defaults to 60s
+DD_HOST_PROFILING_EXPERIMENTAL_UPLOAD_SYMBOLS=true # optional, defaults to false
 ```
 
 Then, you can run the profiler with the following command:
@@ -67,7 +68,7 @@ Then, you can run the profiler with the following command:
 docker-compose up
 ```
 
-The profiler will submit profiling data to the Datadog Agent using the value of DD_OTEL_HOST_PROFILER_SERVICE as the service name.
+The profiler will submit profiling data to the Datadog Agent using the value of DD_SERVICE as the service name.
 
 # Legal
 

--- a/cli_flags.go
+++ b/cli_flags.go
@@ -9,18 +9,15 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"strings"
 	"time"
 
-	"github.com/DataDog/dd-otel-host-profiler/version"
 	cebpf "github.com/cilium/ebpf"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tracer"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v3"
 
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tracer"
+	"github.com/DataDog/dd-otel-host-profiler/version"
 )
-
-type envVarType int
 
 const (
 	// Default values for CLI flags
@@ -31,18 +28,12 @@ const (
 	defaultProbabilisticThreshold = tracer.ProbabilisticThresholdMax
 	defaultProbabilisticInterval  = 1 * time.Minute
 	defaultArgSendErrorFrames     = false
-	defaultArgCollAgentAddr       = "http://localhost:8126"
+	defaultArgAgentURL            = "http://localhost:8126"
 
 	// This is the X in 2^(n + x) where n is the default hardcoded map size value
 	defaultArgMapScaleFactor = 0
 	// 1TB of executable address space
 	maxArgMapScaleFactor = 8
-)
-
-const (
-	shortEnvVar = envVarType(iota)
-	longEnvVar
-	experimentalEnvVar
 )
 
 type arguments struct {
@@ -78,32 +69,6 @@ type arguments struct {
 	cmd                    *cli.Command
 }
 
-func addDefaultEnvVarWithName[T any, C any, VC cli.ValueCreator[T, C]](flag *cli.FlagBase[T, C, VC],
-	envVarType envVarType, name string) *cli.FlagBase[T, C, VC] {
-	const otelProfilerPrefix = "DD_HOST_"
-	var prefix string
-	switch envVarType {
-	case shortEnvVar:
-		prefix = ""
-	case longEnvVar:
-		prefix = "PROFILING_"
-	case experimentalEnvVar:
-		prefix = "PROFILING_EXPERIMENTAL_"
-	}
-
-	envVarName := "DD_" + prefix + name
-	prefixedEnvvarName := otelProfilerPrefix + prefix + name
-
-	flag.Sources.Append(cli.EnvVars(prefixedEnvvarName, envVarName))
-	return flag
-}
-
-func addDefaultEnvVar[T any, C any, VC cli.ValueCreator[T, C]](flag *cli.FlagBase[T, C, VC],
-	envVarType envVarType) *cli.FlagBase[T, C, VC] {
-	name := strings.ReplaceAll(strings.ToUpper(flag.Name), "-", "_")
-	return addDefaultEnvVarWithName(flag, envVarType, name)
-}
-
 func parseArgs() (*arguments, error) {
 	var args arguments
 	versionInfo := version.GetVersionInfo()
@@ -124,99 +89,92 @@ func parseArgs() (*arguments, error) {
 		Copyright: copyright,
 		Version:   versionInfo.Version,
 		Flags: []cli.Flag{
-			addDefaultEnvVar(
-				&cli.UintFlag{
-					Name:        "bpf-log-level",
-					Value:       0,
-					Usage:       "Log level of the eBPF verifier output (0,1,2).",
-					Destination: &args.bpfVerifierLogLevel,
-				}, longEnvVar),
-			addDefaultEnvVar(
-				&cli.UintFlag{
-					Name:  "bpf-log-size",
-					Value: cebpf.DefaultVerifierLogSize,
-					Usage: "Size in bytes that will be allocated for the eBPF verifier output. " +
-						"Only takes effect if bpf-log-level > 0.",
-					Destination: &args.bpfVerifierLogSize,
-				}, longEnvVar),
-			addDefaultEnvVarWithName(
-				&cli.StringFlag{
-					Name:        "agent-url",
-					Aliases:     []string{"U"},
-					Value:       defaultArgCollAgentAddr,
-					Usage:       "The Datadog agent URL in the format of http://host:port.",
-					Destination: &args.collAgentAddr,
-				}, shortEnvVar, "TRACE_AGENT_URL"),
-			addDefaultEnvVar(
-				&cli.StringFlag{
-					Name:        "service",
-					Aliases:     []string{"S"},
-					Usage:       "Service name.",
-					Destination: &args.serviceName,
-				}, shortEnvVar),
-			addDefaultEnvVarWithName(
-				&cli.StringFlag{
-					Name:        "environment",
-					Aliases:     []string{"E"},
-					Value:       "dd-otel-host-profiler",
-					Usage:       "The name of the environment to use in the Datadog UI.",
-					Destination: &args.environment,
-				}, shortEnvVar, "ENV"),
-			addDefaultEnvVarWithName(
-				&cli.StringFlag{
-					Name:        "service-version",
-					Aliases:     []string{"V"},
-					Usage:       "Version of the service being profiled.",
-					Destination: &args.serviceVersion,
-				}, shortEnvVar, "VERSION"),
-			addDefaultEnvVar(
-				&cli.StringFlag{
-					Name:        "tags",
-					Usage:       "User-specified tags separated by ',': key1:value1,key2:value2.",
-					Destination: &args.tags,
-				}, shortEnvVar),
-			addDefaultEnvVar(
-				&cli.UintFlag{
-					Name:  "map-scale-factor",
-					Value: defaultArgMapScaleFactor,
-					Usage: fmt.Sprintf("Scaling factor for eBPF map sizes. "+
-						"Every increase by 1 doubles the map size. Increase if you see eBPF map size errors. "+
-						"Default is %d corresponding to 4GB of executable address space, max is %d.",
-						defaultArgMapScaleFactor, maxArgMapScaleFactor),
-					Destination: &args.mapScaleFactor,
-				}, longEnvVar),
-			addDefaultEnvVar(
-				&cli.DurationFlag{
-					Name:        "monitor-interval",
-					Value:       defaultArgMonitorInterval,
-					Usage:       "Set the monitor interval in seconds.",
-					Destination: &args.monitorInterval,
-				}, longEnvVar),
-			addDefaultEnvVar(
-				&cli.DurationFlag{
-					Name:  "clock-sync-interval",
-					Value: defaultClockSyncInterval,
-					Usage: "Set the sync interval with the realtime clock. " +
-						"If zero, monotonic-realtime clock sync will be performed once, " +
-						"on agent startup, but not periodically.",
-					Destination: &args.clockSyncInterval,
-				}, longEnvVar),
-			addDefaultEnvVar(
-				&cli.BoolFlag{
-					Name:  "no-kernel-version-check",
-					Value: false,
-					Usage: "Disable checking kernel version for eBPF support. " +
-						"Use at your own risk, to run the agent on older kernels with backported eBPF features.",
-					Destination: &args.noKernelVersionCheck,
-				}, longEnvVar),
-			addDefaultEnvVar(
-				&cli.DurationFlag{
-					Name:        "probabilistic-interval",
-					Value:       defaultProbabilisticInterval,
-					Usage:       "Time interval for which probabilistic profiling will be enabled or disabled.",
-					Destination: &args.probabilisticInterval,
-				}, longEnvVar),
-			addDefaultEnvVar(&cli.UintFlag{
+			&cli.UintFlag{
+				Name:        "bpf-log-level",
+				Value:       0,
+				Usage:       "Log level of the eBPF verifier output (0,1,2).",
+				Destination: &args.bpfVerifierLogLevel,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_BPF_LOG_LEVEL"),
+			},
+			&cli.UintFlag{
+				Name:  "bpf-log-size",
+				Value: cebpf.DefaultVerifierLogSize,
+				Usage: "Size in bytes that will be allocated for the eBPF verifier output. " +
+					"Only takes effect if bpf-log-level > 0.",
+				Destination: &args.bpfVerifierLogSize,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_BPF_LOG_SIZE"),
+			},
+			&cli.StringFlag{
+				Name:        "agent-url",
+				Aliases:     []string{"U"},
+				Value:       defaultArgAgentURL,
+				Usage:       "The Datadog agent URL in the format of http://host:port.",
+				Destination: &args.collAgentAddr,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_AGENT_URL", "DD_AGENT_URL"),
+			},
+			&cli.StringFlag{
+				Name:        "service",
+				Aliases:     []string{"S"},
+				Value:       "dd-otel-host-profiler",
+				Usage:       "Service name.",
+				Destination: &args.serviceName,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_SERVICE", "DD_SERVICE"),
+			},
+			&cli.StringFlag{
+				Name:        "environment",
+				Aliases:     []string{"E"},
+				Usage:       "The name of the environment to use in the Datadog UI.",
+				Destination: &args.environment,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_ENV", "DD_ENV"),
+			},
+			&cli.StringFlag{
+				Name:        "tags",
+				Usage:       "User-specified tags separated by ',': key1:value1,key2:value2.",
+				Destination: &args.tags,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_TAGS", "DD_TAGS"),
+			},
+			&cli.UintFlag{
+				Name:  "map-scale-factor",
+				Value: defaultArgMapScaleFactor,
+				Usage: fmt.Sprintf("Scaling factor for eBPF map sizes. "+
+					"Every increase by 1 doubles the map size. Increase if you see eBPF map size errors. "+
+					"Default is %d corresponding to 4GB of executable address space, max is %d.",
+					defaultArgMapScaleFactor, maxArgMapScaleFactor),
+				Destination: &args.mapScaleFactor,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_MAP_SCALE_FACTOR"),
+			},
+			&cli.DurationFlag{
+				Name:        "monitor-interval",
+				Value:       defaultArgMonitorInterval,
+				Usage:       "Set the monitor interval in seconds.",
+				Destination: &args.monitorInterval,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_MONITOR_INTERVAL"),
+			},
+			&cli.DurationFlag{
+				Name:  "clock-sync-interval",
+				Value: defaultClockSyncInterval,
+				Usage: "Set the sync interval with the realtime clock. " +
+					"If zero, monotonic-realtime clock sync will be performed once, " +
+					"on agent startup, but not periodically.",
+				Destination: &args.clockSyncInterval,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_CLOCK_SYNC_INTERVAL"),
+			},
+			&cli.BoolFlag{
+				Name:  "no-kernel-version-check",
+				Value: false,
+				Usage: "Disable checking kernel version for eBPF support. " +
+					"Use at your own risk, to run the agent on older kernels with backported eBPF features.",
+				Destination: &args.noKernelVersionCheck,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_NO_KERNEL_VERSION_CHECK"),
+			},
+			&cli.DurationFlag{
+				Name:        "probabilistic-interval",
+				Value:       defaultProbabilisticInterval,
+				Usage:       "Time interval for which probabilistic profiling will be enabled or disabled.",
+				Destination: &args.probabilisticInterval,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_PROBABILISTIC_INTERVAL"),
+			},
+			&cli.UintFlag{
 				Name:  "probabilistic-threshold",
 				Value: defaultProbabilisticThreshold,
 				Usage: fmt.Sprintf("If set to a value between 1 and %d will enable probabilistic profiling: "+
@@ -225,136 +183,125 @@ func parseArgs() (*arguments, error) {
 					"random number, the agent will collect profiles from this system for the duration of the interval.",
 					tracer.ProbabilisticThresholdMax-1, tracer.ProbabilisticThresholdMax-1),
 				Destination: &args.probabilisticThreshold,
-			}, longEnvVar),
-			addDefaultEnvVar(&cli.DurationFlag{
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_PROBABILISTIC_THRESHOLD"),
+			},
+			&cli.DurationFlag{
 				Name:        "upload-period",
 				Value:       defaultArgReporterInterval,
 				Usage:       "Set the reporter's interval in seconds.",
 				Destination: &args.reporterInterval,
-			}, longEnvVar),
-			addDefaultEnvVar(&cli.UintFlag{
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_UPLOAD_PERIOD"),
+			},
+			&cli.UintFlag{
 				Name:        "sampling-rate",
 				Value:       defaultArgSamplesPerSecond,
 				Usage:       "Set the frequency (in Hz) of stack trace sampling.",
 				Destination: &args.samplesPerSecond,
-			}, longEnvVar),
-			addDefaultEnvVarWithName(
-				&cli.BoolFlag{
-					Name:        "timeline",
-					Value:       false,
-					Usage:       "Enable timeline feature.",
-					Destination: &args.timeline,
-				}, longEnvVar, "TIMELINE_ENABLED"),
-			addDefaultEnvVar(
-				&cli.BoolFlag{
-					Name:        "send-error-frames",
-					Value:       defaultArgSendErrorFrames,
-					Usage:       "Send error frames",
-					Destination: &args.sendErrorFrames,
-				}, longEnvVar),
-			addDefaultEnvVar(
-				&cli.StringFlag{
-					Name:        "tracers",
-					Aliases:     []string{"t"},
-					Value:       "all",
-					Usage:       "Comma-separated list of interpreter tracers to include.",
-					Destination: &args.tracers,
-				}, longEnvVar),
-			addDefaultEnvVar(
-				&cli.BoolFlag{
-					Name:        "verbose",
-					Aliases:     []string{"v"},
-					Value:       false,
-					Usage:       "Enable verbose logging and debugging capabilities.",
-					Destination: &args.verboseMode,
-				}, longEnvVar),
-			addDefaultEnvVar(
-				&cli.StringFlag{
-					Name:        "pprof-prefix",
-					Usage:       "Dump pprof profile to `FILE`.",
-					Destination: &args.pprofPrefix,
-				}, longEnvVar),
-			addDefaultEnvVar(
-				&cli.StringFlag{
-					Name: "node",
-					Usage: "The name of the node that the profiler is running on. " +
-						"If on Kubernetes, this must match the Kubernetes node name.",
-					Destination: &args.node,
-				}, longEnvVar),
-			addDefaultEnvVar(
-				&cli.BoolFlag{
-					Name:        "upload-symbols",
-					Value:       false,
-					Usage:       "Enable local symbol upload.",
-					Hidden:      true,
-					Destination: &args.uploadSymbols,
-				}, longEnvVar),
-			&cli.BoolWithInverseFlag{
-				BoolFlag: addDefaultEnvVar(
-					&cli.BoolFlag{
-						Name:  "upload-dynamic-symbols",
-						Usage: "Enable dynamic symbols upload.",
-						// Cannot set default value to true because it fails at runtime with:
-						//   "Failure to parse arguments: cannot set both flags `--upload-dynamic-symbols`
-						//    and `--no-upload-dynamic-symbols`"
-						// Value:       true,
-						DefaultText: "true",
-						Hidden:      true,
-					}, experimentalEnvVar),
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_SAMPLING_RATE"),
 			},
-			addDefaultEnvVar(
-				&cli.BoolFlag{
-					Name:        "upload-symbols-dry-run",
-					Value:       false,
-					Usage:       "Local symbol upload dry-run.",
-					Hidden:      true,
-					Destination: &args.uploadSymbolsDryRun,
-				}, experimentalEnvVar),
-			addDefaultEnvVar(
-				&cli.StringFlag{
-					Name:        "api-key",
-					Usage:       "Datadog API key.",
-					Hidden:      true,
-					Destination: &args.apiKey,
-					Validator: func(s string) error {
-						if s == "" || isAPIKeyValid(s) {
-							return nil
-						}
-						return errors.New("API key is not valid")
-					},
-				}, shortEnvVar),
-			addDefaultEnvVar(
-				&cli.StringFlag{
-					Name:        "app-key",
-					Usage:       "Datadog APP key.",
-					Hidden:      true,
-					Destination: &args.appKey,
-					Validator: func(s string) error {
-						if s == "" || isAPPKeyValid(s) {
-							return nil
-						}
-						return errors.New("APP key is not valid")
-					},
-				}, shortEnvVar),
-			addDefaultEnvVar(
-				&cli.StringFlag{
-					Name:        "site",
-					Value:       "datadoghq.com",
-					Usage:       "Datadog site.",
-					Hidden:      true,
-					Destination: &args.site,
-				}, shortEnvVar),
+			&cli.BoolFlag{
+				Name:        "timeline",
+				Value:       false,
+				Usage:       "Enable timeline feature.",
+				Destination: &args.timeline,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_TIMELINE_ENABLED"),
+			},
+			&cli.BoolFlag{
+				Name:        "send-error-frames",
+				Value:       defaultArgSendErrorFrames,
+				Usage:       "Send error frames",
+				Destination: &args.sendErrorFrames,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_SEND_ERROR_FRAMES"),
+			},
+			&cli.StringFlag{
+				Name:        "tracers",
+				Aliases:     []string{"t"},
+				Value:       "all",
+				Usage:       "Comma-separated list of interpreter tracers to include.",
+				Destination: &args.tracers,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_TRACERS"),
+			},
+			&cli.BoolFlag{
+				Name:        "verbose",
+				Aliases:     []string{"v"},
+				Value:       false,
+				Usage:       "Enable verbose logging and debugging capabilities.",
+				Destination: &args.verboseMode,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_VERBOSE"),
+			},
+			&cli.StringFlag{
+				Name:        "pprof-prefix",
+				Usage:       "Dump pprof profile to `FILE`.",
+				Destination: &args.pprofPrefix,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_PPROF_PREFIX"),
+			},
+			&cli.StringFlag{
+				Name: "node",
+				Usage: "The name of the node that the profiler is running on. " +
+					"If on Kubernetes, this must match the Kubernetes node name.",
+				Destination: &args.node,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_NODE"),
+			},
+			&cli.BoolFlag{
+				Name:        "upload-symbols",
+				Value:       false,
+				Usage:       "Enable local symbol upload.",
+				Hidden:      true,
+				Destination: &args.uploadSymbols,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_EXPERIMENTAL_UPLOAD_SYMBOLS"),
+			},
+			&cli.BoolFlag{
+				Name:        "upload-dynamic-symbols",
+				Usage:       "Enable dynamic symbols upload.",
+				Value:       true,
+				Hidden:      true,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_EXPERIMENTAL_UPLOAD_DYNAMIC_SYMBOLS"),
+				Destination: &args.uploadDynamicSymbols,
+			},
+			&cli.BoolFlag{
+				Name:        "upload-symbols-dry-run",
+				Value:       false,
+				Usage:       "Local symbol upload dry-run.",
+				Hidden:      true,
+				Destination: &args.uploadSymbolsDryRun,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_EXPERIMENTAL_UPLOAD_SYMBOLS_DRY_RUN"),
+			},
+			&cli.StringFlag{
+				Name:        "api-key",
+				Usage:       "Datadog API key.",
+				Hidden:      true,
+				Destination: &args.apiKey,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_API_KEY", "DD_API_KEY"),
+				Validator: func(s string) error {
+					if s == "" || isAPIKeyValid(s) {
+						return nil
+					}
+					return errors.New("API key is not valid")
+				},
+			},
+			&cli.StringFlag{
+				Name:        "app-key",
+				Usage:       "Datadog APP key.",
+				Hidden:      true,
+				Destination: &args.appKey,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_APP_KEY", "DD_APP_KEY"),
+				Validator: func(s string) error {
+					if s == "" || isAPPKeyValid(s) {
+						return nil
+					}
+					return errors.New("APP key is not valid")
+				},
+			},
+			&cli.StringFlag{
+				Name:        "site",
+				Value:       "datadoghq.com",
+				Usage:       "Datadog site.",
+				Hidden:      true,
+				Destination: &args.site,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_SITE", "DD_SITE"),
+			},
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
-			// Workaround for the fact that cli.BoolWithInverseFlag does not work with a false default value
-			if cmd.IsSet("upload-dynamic-symbols") {
-				args.uploadDynamicSymbols = cmd.Bool("upload-dynamic-symbols")
-			} else {
-				if cmd.Set("upload-dynamic-symbols", "true") != nil {
-					return errors.New("cannot set flag `--upload-dynamic-symbols`")
-				}
-				args.uploadDynamicSymbols = true
-			}
 			args.cmd = cmd
 			return nil
 		},
@@ -367,7 +314,6 @@ func parseArgs() (*arguments, error) {
 	if args.cmd == nil {
 		return nil, nil
 	}
-
 	return &args, nil
 }
 

--- a/cli_flags.go
+++ b/cli_flags.go
@@ -108,9 +108,9 @@ func parseArgs() (*arguments, error) {
 				Name:        "agent-url",
 				Aliases:     []string{"U"},
 				Value:       defaultArgAgentURL,
-				Usage:       "The Datadog agent URL in the format of http://host:port.",
+				Usage:       "The Datadog trace agent URL in the format of http://host:port.",
 				Destination: &args.collAgentAddr,
-				Sources:     cli.EnvVars("DD_HOST_PROFILING_AGENT_URL", "DD_AGENT_URL"),
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_TRACE_AGENT_URL", "DD_TRACE_AGENT_URL"),
 			},
 			&cli.StringFlag{
 				Name:        "service",

--- a/cli_flags.go
+++ b/cli_flags.go
@@ -22,7 +22,7 @@ import (
 const (
 	// Default values for CLI flags
 	defaultArgSamplesPerSecond    = 20
-	defaultArgReporterInterval    = 5.0 * time.Second
+	defaultArgReporterInterval    = 60 * time.Second
 	defaultArgMonitorInterval     = 5.0 * time.Second
 	defaultClockSyncInterval      = 3 * time.Minute
 	defaultProbabilisticThreshold = tracer.ProbabilisticThresholdMax

--- a/cli_flags.go
+++ b/cli_flags.go
@@ -39,7 +39,7 @@ const (
 type arguments struct {
 	bpfVerifierLogLevel    uint64
 	bpfVerifierLogSize     uint64
-	collAgentAddr          string
+	agentURL               string
 	copyright              bool
 	mapScaleFactor         uint64
 	monitorInterval        time.Duration
@@ -109,7 +109,7 @@ func parseArgs() (*arguments, error) {
 				Aliases:     []string{"U"},
 				Value:       defaultArgAgentURL,
 				Usage:       "The Datadog trace agent URL in the format of http://host:port.",
-				Destination: &args.collAgentAddr,
+				Destination: &args.agentURL,
 				Sources:     cli.EnvVars("DD_HOST_PROFILING_TRACE_AGENT_URL", "DD_TRACE_AGENT_URL"),
 			},
 			&cli.StringFlag{

--- a/doc/running-in-docker.md
+++ b/doc/running-in-docker.md
@@ -16,7 +16,7 @@ To run the profiler in Docker, you should ensure the following requirements are 
 1. The container has host PID enabled.
 2. The container is running in privileged mode.
 3. The container has the `SYS_ADMIN` capability.
-4. The `DD_OTEL_HOST_PROFILER_COLLECTION_AGENT` environment variable is set to the address of the Datadog agent: `http://<agent_address>:8126`.
+4. The `DD_TRACE_AGENT_URL` environment variable is set to the address of the Datadog agent: `http://<agent_address>:8126`.
 
 Additionally, to be able to resolve container names, the profiler needs access to the container runtime socket. This is done by mounting the container runtime socket into the profiler container.
 
@@ -27,8 +27,8 @@ docker run \
   --pid=host \
   --privileged \
   --cap-add=SYS_ADMIN \
-  -e DD_OTEL_HOST_PROFILER_COLLECTION_AGENT=http://<agent_address>:8126 \
-  -e DD_OTEL_HOST_PROFILER_SERVICE="$(hostname)" \
+  -e DD_TRACE_AGENT_URL=http://<agent_address>:8126 \
+  -e DD_SERVICE="$(hostname)" \
   -v /var/run/docker.sock:/var/run/docker.sock \
   ghcr.io/datadog/dd-otel-host-profiler:latest
 ```

--- a/doc/running-in-kubernetes.md
+++ b/doc/running-in-kubernetes.md
@@ -17,7 +17,7 @@ To run the profiler in a Kubernetes cluster, you should ensure the following req
 2. The container is running in privileged mode.
 3. The `procMount` security context field is set to `Unmasked`.
 4. The container has the `SYS_ADMIN` capability.
-5. The `DD_OTEL_HOST_PROFILER_COLLECTION_AGENT` environment variable is set to the address of the Datadog agent: `http://<agent_address>:8126`.
+5. The `DD_TRACE_AGENT_URL` environment variable is set to the address of the Datadog agent: `http://<agent_address>:8126`.
 
 Additionally, to be able to resolve pod names in Kubernetes, the profiler needs:
 * The `KUBERNETES_NODE_NAME` environment variable set to the name of the node where the profiler is running.
@@ -47,13 +47,13 @@ spec:
             add:
             - SYS_ADMIN # Adding SYS_ADMIN capability (4.)
         env:
-        - name: DD_OTEL_HOST_PROFILER_COLLECTION_AGENT # The address of the Datadog agent (5.)
+        - name: DD_TRACE_AGENT_URL # The address of the Datadog agent (5.)
           value: "http://<agent_address>:8126"
         - name: KUBERNETES_NODE_NAME # this is needed to resolve pod names in Kubernetes
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: DD_OTEL_HOST_PROFILER_SERVICE
+        - name: DD_SERVICE
           value: "$(KUBERNETES_NODE_NAME)" # will inherit the variable set above
         # ...
         volumeMounts:

--- a/doc/running-on-host.md
+++ b/doc/running-on-host.md
@@ -19,8 +19,7 @@ Alternatively, you can build the profiler from source. The following instruction
 To build the profiler, you can use the following commands:
 
 ```
-make docker-image
-make agent
+make profiler-in-docker
 ```
 
 This will create a `dd-otel-host-profiler` binary in the current directory.
@@ -38,7 +37,7 @@ sudo mount -t debugfs none /sys/kernel/debug
 After that, you can start the profiler as shown below (make sure you run it as root):
 
 ```
-sudo dd-otel-host-profiler -service "$(hostname)" -collection-agent "http://localhost:8126"
+sudo dd-otel-host-profiler --service "$(hostname)" --agent-url "http://localhost:8126"
 ```
 
-If your datadog agent is reachable under a different address, you can modify the `-collection-agent` parameter accordingly.
+If your Datadog agent is reachable under a different address, you can modify the `--agent-url` parameter accordingly.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     secrets:
       - dd-api-key
       - dd-app-key
-    command: ['/bin/sh', '-c', 'export DD_API_KEY=$$(cat /run/secrets/dd-api-key) DD_APP_KEY=$$(cat /run/secrets/dd-app-key); sudo mount -t debugfs none /sys/kernel/debug && cd /app && make && sudo -E /app/dd-otel-host-profiler --agent-url "http://datadog-agent:8126" --sampling-rate 20 --pprof-prefix ./cpu_']
+    command: ['/bin/sh', '-c', 'export DD_API_KEY=$$(cat /run/secrets/dd-api-key) DD_APP_KEY=$$(cat /run/secrets/dd-app-key); sudo mount -t debugfs none /sys/kernel/debug && cd /app && make && sudo -E /app/dd-otel-host-profiler --agent-url "http://datadog-agent:8126" --sampling-rate 20']
 
   datadog-agent:
     image: gcr.io/datadoghq/agent:7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     secrets:
       - dd-api-key
-    command: ['/bin/sh', '-c', 'export DD_API_KEY=$$(cat /run/secrets/dd-api-key); sudo mount -t debugfs none /sys/kernel/debug && cd /app && make && sudo -E /app/dd-otel-host-profiler -service "$DD_OTEL_HOST_PROFILER_SERVICE:-dd-otel-host-profiler-dev}" -collection-agent "http://datadog-agent:8126" -reporter-interval ${DD_OTEL_HOST_PROFILER_REPORTER_INTERVAL:-60s} -samples-per-second 20 -save-cpuprofile']
+    command: ['/bin/sh', '-c', 'export DD_API_KEY=$$(cat /run/secrets/dd-api-key); sudo mount -t debugfs none /sys/kernel/debug && cd /app && make && sudo -E /app/dd-otel-host-profiler --service "$DD_OTEL_HOST_PROFILER_SERVICE:-dd-otel-host-profiler-dev}" -collection-agent "http://datadog-agent:8126" --upload-period ${DD_OTEL_HOST_PROFILER_REPORTER_INTERVAL:-60s} --sampling-rate 20 --dump-cpu-profile cpu.pprof']
 
   datadog-agent:
     image: gcr.io/datadoghq/agent:7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,25 @@
 name: "dd-otel-host-profiler"
 
 services:
-  agent:
+  full-host-profiler:
     build:
       context: .
     privileged: true
     pid: "host"
+    environment:
+      DD_SITE: ${DD_SITE:-datadoghq.com}
+      DD_SERVICE: ${DD_SERVICE:-dd-otel-host-profiler-dev}
+      DD_HOST_PROFILING_UPLOAD_PERIOD: ${DD_HOST_PROFILING_UPLOAD_PERIOD:-60s}
+      DD_HOST_PROFILING_EXPERIMENTAL_UPLOAD_SYMBOLS: ${DD_HOST_PROFILING_EXPERIMENTAL_UPLOAD_SYMBOLS:-false}
+      DD_HOST_PROFILING_EXPERIMENTAL_UPLOAD_DYNAMIC_SYMBOLS: ${DD_HOST_PROFILING_EXPERIMENTAL_UPLOAD_DYNAMIC_SYMBOLS:-true}
+      VERSION: ${VERSION:-local-dev}
     volumes:
       - .:/app
       - /var/run/docker.sock:/var/run/docker.sock:ro
     secrets:
       - dd-api-key
-    command: ['/bin/sh', '-c', 'export DD_API_KEY=$$(cat /run/secrets/dd-api-key); sudo mount -t debugfs none /sys/kernel/debug && cd /app && make && sudo -E /app/dd-otel-host-profiler --service "$DD_OTEL_HOST_PROFILER_SERVICE:-dd-otel-host-profiler-dev}" -collection-agent "http://datadog-agent:8126" --upload-period ${DD_OTEL_HOST_PROFILER_REPORTER_INTERVAL:-60s} --sampling-rate 20 --dump-cpu-profile cpu.pprof']
+      - dd-app-key
+    command: ['/bin/sh', '-c', 'export DD_API_KEY=$$(cat /run/secrets/dd-api-key) DD_APP_KEY=$$(cat /run/secrets/dd-app-key); sudo mount -t debugfs none /sys/kernel/debug && cd /app && make && sudo -E /app/dd-otel-host-profiler --agent-url "http://datadog-agent:8126" --sampling-rate 20 --pprof-prefix ./cpu_']
 
   datadog-agent:
     image: gcr.io/datadoghq/agent:7
@@ -29,3 +37,5 @@ services:
 secrets:
   dd-api-key:
     environment: DD_API_KEY
+  dd-app-key:
+    environment: DD_APP_KEY

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,10 @@ require (
 	github.com/google/pprof v0.0.0-20240829160300-da1f7e9f2b25
 	github.com/jsimonetti/rtnetlink v1.4.2
 	github.com/open-telemetry/opentelemetry-ebpf-profiler v0.0.0-20240918090752-0a8979a41728
-	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
 	github.com/tklauser/numcpus v0.8.0
+	github.com/urfave/cli/v3 v3.0.0-alpha9
 	github.com/zeebo/xxh3 v1.0.2
 	golang.org/x/sys v0.21.0
 	k8s.io/api v0.31.0
@@ -88,6 +88,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0 // indirect
 	go.opentelemetry.io/otel v1.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,6 @@ github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bl
 github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/peterbourgon/ff/v3 v3.4.0 h1:QBvM/rizZM1cB0p0lGMdmR7HxZeI/ZrBWB4DqLkMUBc=
-github.com/peterbourgon/ff/v3 v3.4.0/go.mod h1:zjJVUhx+twciwfDl0zBcFzl4dW8axCRyXE/eKY9RztQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -225,8 +223,12 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tklauser/numcpus v0.8.0 h1:Mx4Wwe/FjZLeQsK/6kt2EOepwwSl7SmJrK5bV/dXYgY=
 github.com/tklauser/numcpus v0.8.0/go.mod h1:ZJZlAY+dmR4eut8epnzf0u/VwodKmryxR8txiloSqBE=
+github.com/urfave/cli/v3 v3.0.0-alpha9 h1:P0RMy5fQm1AslQS+XCmy9UknDXctOmG/q/FZkUFnJSo=
+github.com/urfave/cli/v3 v3.0.0-alpha9/go.mod h1:0kK/RUFHyh+yIKSfWxwheGndfnrvYSmYFVeKCh03ZUc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=

--- a/helpers.go
+++ b/helpers.go
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var ValidTagKeyRegex = regexp.MustCompile(`^a-zA-Z[a-zA-Z0-9-._/]+$`)
+var ValidTagKeyRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-._/]+$`)
 var ValidTagValueRegex = regexp.MustCompile(`^[a-zA-Z0-9-:._/]*$`)
 
 func getKernelVersion() (string, error) {

--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func mainWithExitCode() exitCode {
 		return failure("Failed to parse the included tracers: %v", err)
 	}
 
-	metadataCollector := hostmetadata.NewCollector(args.collAgentAddr)
+	metadataCollector := hostmetadata.NewCollector(args.agentURL)
 	metadataCollector.AddCustomData("os.type", "linux")
 
 	kernelVersion, err := getKernelVersion()
@@ -158,7 +158,7 @@ func mainWithExitCode() exitCode {
 	metadataCollector.AddCustomData("os.kernel.release", kernelVersion)
 
 	// hostname and sourceIP will be populated from the root namespace.
-	hostname, sourceIP, err := getHostnameAndSourceIP(args.collAgentAddr)
+	hostname, sourceIP, err := getHostnameAndSourceIP(args.agentURL)
 	if err != nil {
 		log.Warnf("Failed to fetch metadata information in the root namespace: %v", err)
 	}
@@ -189,9 +189,9 @@ func mainWithExitCode() exitCode {
 		}
 		apiKey = args.apiKey
 	} else {
-		intakeURL, err = intakeURLForAgent(args.collAgentAddr)
+		intakeURL, err = intakeURLForAgent(args.agentURL)
 		if err != nil {
-			return failure("Failed to get intake URL from agent URL %v: %v", args.collAgentAddr, err)
+			return failure("Failed to get intake URL from agent URL %v: %v", args.agentURL, err)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -17,26 +17,19 @@ import (
 	"runtime"
 	"time"
 
-	//nolint:gosec
-	_ "net/http/pprof"
-
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/times"
-	tracertypes "github.com/open-telemetry/opentelemetry-ebpf-profiler/tracer/types"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
-	"github.com/tklauser/numcpus"
-	"golang.org/x/sys/unix"
-
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/host"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tracehandler"
-
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/hostmetadata"
-
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/metrics"
 	otelreporter "github.com/open-telemetry/opentelemetry-ebpf-profiler/reporter"
-
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/times"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tracehandler"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/tracer"
+	tracertypes "github.com/open-telemetry/opentelemetry-ebpf-profiler/tracer/types"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/tklauser/numcpus"
+	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/dd-otel-host-profiler/containermetadata"
 	"github.com/DataDog/dd-otel-host-profiler/reporter"

--- a/reporter/config.go
+++ b/reporter/config.go
@@ -24,32 +24,41 @@ func MakeTag(key, value string) Tag {
 }
 
 type Config struct {
-	// Name defines the name of the agent.
-	Name string
 	// Version defines the version of the agent.
 	Version string
-	// CollAgentAddr defines the destination of the backend connection.
-	CollAgentAddr string
+	// IntakeURL defines the URL of profiling intake.
+	IntakeURL string
 	// CacheSize defines the size of the reporter caches.
 	CacheSize uint32
 	// samplesPerSecond defines the number of samples per second.
 	SamplesPerSecond int
-	// HostID is the host ID to be sent to the collection agent.
-	HostID uint64
-	// KernelVersion is the kernel version of the host.
-	KernelVersion string
-	// HostName is the name of the host.
-	HostName string
-	// IPAddress is the IP address of the host.
-	IPAddress string
 	// ReportInterval defines the interval at which the agent reports data to the collection agent.
 	ReportInterval time.Duration
-	// SaveCPUProfile defines whether the agent should dump a pprof CPU profile on disk.
-	SaveCPUProfile bool
+	// PprofPrefix defines a file where the agent should dump pprof CPU profile.
+	PprofPrefix string
 	// Tags is a list of tags to be sent to the collection agent.
 	Tags Tags
 	// Whether to include timestamps on samples for the timeline feature
 	Timeline bool
-	// SymbolUpload defines whether the agent should upload debug symbols to the backend.
-	UploadSymbols bool
+	// API key for agentless mode
+	APIKey string
+	// SymbolUploaderConfig defines the configuration for the symbol uploader.
+	SymbolUploaderConfig SymbolUploaderConfig
+}
+
+type SymbolUploaderConfig struct {
+	// Enabled defines whether the agent should upload debug symbols to the backend.
+	Enabled bool
+	// UploadDynamicSymbols defines whether the agent should upload dynamic symbols to the backend.
+	UploadDynamicSymbols bool
+	// DryRun defines whether the agent should upload debug symbols to the backend in dry-run mode.
+	DryRun bool
+	// DataDog API key
+	APIKey string
+	// DataDog APP key
+	APPKey string
+	// Site is the site to upload symbols to.
+	Site string
+	// Version is the version of the profiler.
+	Version string
 }

--- a/reporter/datadog_upload.go
+++ b/reporter/datadog_upload.go
@@ -23,7 +23,7 @@ type profileData struct {
 }
 
 func uploadProfiles(ctx context.Context, profiles []profileData, startTime, endTime time.Time,
-	url string, tags Tags, agentVersion string) error {
+	url string, tags Tags, profilerVersion string, apiKey string) error {
 	contentType, body, err := buildMultipartForm(profiles, startTime, endTime, tags)
 	if err != nil {
 		return err
@@ -36,10 +36,10 @@ func uploadProfiles(ctx context.Context, profiles []profileData, startTime, endT
 	}
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Dd-Evp-Origin", profilerName)
-	req.Header.Set("Dd-Evp-Origin-Version", agentVersion)
-
-	// If you're uploading directly to our intake, add the API key here:
-	// req.Header.Set("DD-API-KEY", "xxxx")
+	req.Header.Set("Dd-Evp-Origin-Version", profilerVersion)
+	if apiKey != "" {
+		req.Header.Set("Dd-Api-Key", apiKey)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/reporter/symbol_uploader.go
+++ b/reporter/symbol_uploader.go
@@ -209,7 +209,7 @@ func (d *DatadogSymbolUploader) upload(ctx context.Context, uploadData uploadDat
 
 	existingSymbolSource, err := d.GetExistingSymbolsOnBackend(ctx, e)
 	if err != nil {
-		log.Debugf("Failed to get existing symbols for executable %s: %v", filePath, err)
+		log.Warnf("Failed to get existing symbols for executable %s: %v", filePath, err)
 		return false
 	}
 


### PR DESCRIPTION
# What does this PR do?

Rename env variables used for configuration to be consistent with other Datadog profilers (eg `DD_SERVICE`, `DD_PROFILING_UPLOAD_PERIOD`).
Also add a prefixed version of these variables (eg `DD_HOST_SERVICE`, `DD_HOST_PROFILING_UPLOAD_PERIOD`) that takes precedence over the non-prefixed version for cases where host profiler might be running along side another runtime profiler and a different configuration is needed for the host profiler.