### PR TITLE
Add `SECURITY.md` that indicates how to engage Datadog about security issues.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+## Security Policy
+
+### Reporting a Vulnerability
+
+If you believe you have found a security issue in our code directly, please contact Datadog's security team at
+[security@datadoghq.com][mailto] rather than filing a public issue on GitHub. Our security team will get back to you
+within 24 hours, usually earlier. The security team's PGP key is available for download at
+[`www.datadoghq.com/8869756E.asc.txt`](https://www.datadoghq.com/8869756E.asc.txt) in case you need to encrypt
+communications.
+
+We request that you do not publicly disclose the issue until we had a chance to address it.
+
+[mailto]: mailto:security@datadoghq.com?subject=[github.com/DataDog/orchestrion]%20Vulnerability%20report


### PR DESCRIPTION
# What does this PR do?

Add `SECURITY.md` that indicates how to engage Datadog about security issues.

# Motivation

Fix https://github.com/DataDog/dd-otel-host-profiler/security/code-scanning/51
