### PR TITLE
Remove golangci install script usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.23.1-bookworm@sha256:dba79eb312528369dea87532a65dbe9d4efb26439a0fe
 RUN apt-get update -y && apt-get upgrade -y && apt-get install -y sudo && apt-get clean autoclean && apt-get autoremove --yes 
 
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
-RUN wget -qO- https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0
 
 RUN useradd -ms /bin/bash build
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
# What does this PR do?

Remove golangci install script and replace it with `go install ...`

# Motivation

Make code scanning happy.