### PR TITLE
github: run workflows for dependabot

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.ref }}-codeql
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (Go)

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -4,12 +4,15 @@ on:
   pull_request:
     types: [labeled]
 
+permissions:
+  contents: read
+
 jobs:
   build-release:
     if: ${{ github.event.label.name == 'publish-dev-test' }}
-    name: Build
+    name: Build and Release
     uses: ./.github/workflows/pre-release.yaml
     secrets: inherit
     permissions:
-      contents: read
-      pull-requests: write
+      contents: write
+      packages: write

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,15 @@
+name: Labeled
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  build-release:
+    if: ${{ github.event.label.name == 'publish-dev-test' }}
+    name: Build
+    uses: ./.github/workflows/pre-release.yaml
+    secrets: inherit
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -16,3 +16,4 @@ jobs:
     permissions:
       contents: write
       packages: write
+      pull-requests: write

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened]
     branches: ["**"]
   workflow_call:
 
@@ -13,11 +12,10 @@ permissions:
 
 concurrency:
   group: ${{ github.ref }}
-  cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'publish-dev-test' }}
+  cancel-in-progress: true
 
 jobs:
   versions:
-    if: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'publish-dev-test' }}
     name: Determine versions
     runs-on: ubuntu-24.04
     env:
@@ -36,7 +34,6 @@ jobs:
         run: echo "version=${RELEASE_VERSION}-${GITHUB_SHA::7}.${{ github.run_id }}" >> "${GITHUB_OUTPUT}"
 
   build:
-    if: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'publish-dev-test' }}
     name: Build
     needs: [versions]
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -4,8 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     branches: ["**"]
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: ${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'publish-dev-test' }
 
 jobs:
   versions:

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: ${{ github.ref }}
-  cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'publish-dev-test' }
+  cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'publish-dev-test' }}
 
 jobs:
   versions:

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   versions:
+    if: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'publish-dev-test' }}
     name: Determine versions
     runs-on: ubuntu-24.04
     env:


### PR DESCRIPTION
# What does this PR do?

Currently, we receive two successive actions when dependabot opens a PR, first an `opened` event, then a `labeled` event. the second event cancels the first workflow, however, we don't re-run tests when a PR is labeled except if the label is `publish-dev-test`. this fixes the issue by removing the cancel for all labels except `publish-dev-test`.

Peer investigated with @nsavoire, 🙇 

# Motivation

Run tests for PRs opened by dependabot!

# Additional Notes

N/A

# How to test the change?

N/A
