### PR TITLE
github: run workflows for dependabot

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.ref }}-codeql
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (Go)

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,19 @@
+name: Labeled
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  build-release:
+    if: ${{ github.event.label.name == 'publish-dev-test' }}
+    name: Build and Release
+    uses: ./.github/workflows/pre-release.yaml
+    secrets: inherit
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
     branches: ["**"]
+  workflow_call:
 
 permissions:
   contents: read
@@ -34,7 +34,6 @@ jobs:
         run: echo "version=${RELEASE_VERSION}-${GITHUB_SHA::7}.${{ github.run_id }}" >> "${GITHUB_OUTPUT}"
 
   build:
-    if: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'publish-dev-test' }}
     name: Build
     needs: [versions]
     uses: ./.github/workflows/build.yml


### PR DESCRIPTION
# What does this PR do?

Currently, we receive two successive events when dependabot opens a PR, first an `opened` event, then a `labeled` events, since dependabot always adds the `dependencies` label.

However, the second event cancels the first workflow, since it is part of the same concurrency group. Since the second event is a `labeled` event that isn't about the `publish-dev-test` label, tests are not re-ran in the second workflow. The PR stays stuck waiting for status checks for build and test, and those check will never complete.

We fix this by extracting the "run on publish-dev-test" logic to a separate workflow that calls the pre-release workflow. By creating a separate workflow, this will not impact status checks, since labeled actions will live in a separate namespace under "Labeled / ".

(Thanks to @nsavoire for suggesting this solution and helping debug this!)

# Motivation

Have dependabot PRs run tests accordingly.

# Additional Notes

N / A

# How to test the change?

This was extensively tested in https://github.com/DataDog/dd-otel-host-profiler/pull/32
