### PR TITLE
Fix lint job permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
     steps:
     - name: Check out
       uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1


### PR DESCRIPTION
# What does this PR do?

Add `pull-request: write` permission to lint job.

# Motivation

`pull-request: write` is required to add comments to the PR.