### PR TITLE
containermetadata: make default pattern more restrictive

### DIFF
--- a/containermetadata/containermetadata.go
+++ b/containermetadata/containermetadata.go
@@ -88,7 +88,9 @@ var (
 	dockerBuildkitPattern = regexp.MustCompile(`\d+:.*:/.*/*docker/buildkit/([0-9a-z]+)`)
 	lxcPattern            = regexp.MustCompile(`\d+::/lxc\.(monitor|payload)\.([a-zA-Z]+)/`)
 	containerdPattern     = regexp.MustCompile(`\d+:.+:/([a-zA-Z0-9_-]+)/+([a-zA-Z0-9_-]+)`)
-	defaultPattern        = regexp.MustCompile(`^.*/(?:.*[-:])?([0-9a-f]+)(?:\.|\s*$)`)
+	// The inner container ID pattern is extracted from:
+	// https://github.com/DataDog/datadog-agent/blob/6e43db2/pkg/util/cgroups/reader.go#L24C24-L24C90
+	defaultPattern = regexp.MustCompile(`^.*/(?:.*[-:])?([0-9a-f]{64})|([0-9a-f]{32}-\\d+)|([0-9a-f]{8}(-[0-9a-f]{4}){4}$)(?:\.|\s*$)`)
 
 	containerIDPattern = regexp.MustCompile(`.+://([0-9a-f]{64})`)
 

--- a/containermetadata/containermetadata_test.go
+++ b/containermetadata/containermetadata_test.go
@@ -151,6 +151,12 @@ func TestExtractContainerIDFromFile(t *testing.T) {
 				containerdClient: &containerd.Client{},
 			},
 		},
+		{
+			name:           "systemd",
+			cgroupname:     "testdata/cgroupv1systemd",
+			expContainerID: "",
+			expEnv:         envUndefined,
+		},
 	}
 
 	defaultHandler := &containerMetadataProvider{

--- a/containermetadata/testdata/cgroupv1systemd
+++ b/containermetadata/testdata/cgroupv1systemd
@@ -1,0 +1,14 @@
+13:devices:/system.slice/dd.taskapi.service
+12:pids:/system.slice/dd.taskapi.service
+11:cpu,cpuacct:/system.slice/dd.taskapi.service
+10:cpuset:/
+9:memory:/system.slice/dd.taskapi.service
+8:rdma:/
+7:freezer:/
+6:misc:/
+5:hugetlb:/
+4:blkio:/system.slice/dd.taskapi.service
+3:perf_event:/
+2:net_cls,net_prio:/
+1:name=systemd:/system.slice/dd.taskapi.service
+0::/system.slice/dd.taskapi.service


### PR DESCRIPTION
# What does this PR do?

The existing default pattern would match systemd service names which only contain letter a-f (see added test which fails with the current code).

This commit extracts the container regex pattern used by the datadog-agent, and uses it as a default pattern.

This makes the pattern more restrictive, avoiding the addition of an incorrect container_id tags for some systemd services.

# Motivation

Profiles contained an incorrect container id, with the example added in the test. 
![image](https://github.com/user-attachments/assets/1ec0531c-1e13-482f-a133-5b4f812c163a)

# Additional Notes

N/A

# How to test the change?

Added tests, and tested locally in the workspace.
