### PR TITLE
dockerfile: remove gopath override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM golang:1.23.1-bookworm@sha256:dba79eb312528369dea87532a65dbe9d4efb26439a0fe
 
 RUN apt-get update -y && apt-get upgrade -y && apt-get install -y sudo && apt-get clean autoclean && apt-get autoremove --yes 
 
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
-
-ENV GOPATH=
-
 RUN useradd -ms /bin/bash build
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN adduser build sudo
 
 USER build
+
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+
+VOLUME /go


### PR DESCRIPTION
# What does this PR do?

Move the go install command so that it's called by the build user instead of root.

Running go install with root would lead to some folders in /go/pkg/ being owned by root and not writable by the build user, which eventually leads to permission errors when building the profiler, specifically to download new dependencies.

Also put /go in a volume which is persisted between consecutive runs, meaning docker-compose restart will reuse the go cache / go dependencies speeding up builds for local development.

# Motivation

Speed up local builds, fix permissions for `/go` directory.

# Additional Notes

N/A

# How to test the change?

Tested locally with:
```
docker-compose build
docker-compose up -d --force-recreate
# wait for a bit
docker-compose restart
```

And verifying that all commands work, containers are started as expected, and during restart go dependencies are not fetched again.
