### PR TITLE
containermetadata: fix cgroup pattern

### DIFF
--- a/containermetadata/containermetadata.go
+++ b/containermetadata/containermetadata.go
@@ -184,7 +184,7 @@ func NewContainerMetadataProvider(ctx context.Context, nodeName string, monitorI
 		dockerClient:     getDockerClient(),
 		containerdClient: getContainerdClient(),
 		nodeName:         nodeName,
-		cgroupPattern:    "proc/%d/cgroup",
+		cgroupPattern:    "/proc/%d/cgroup",
 	}
 
 	p.deferredPID, err = lru.NewSynced[libpf.PID, libpf.Void](deferredLRUSize,


### PR DESCRIPTION
# What does this PR do?

Fix container metadata detection

# Motivation

A regression in https://github.com/DataDog/dd-otel-host-profiler/pull/40 broke container id detection

# Additional Notes

N/A

# How to test the change?

Tested locally
