### PR TITLE
fix: Use correct profiler version for symbol upload

### DIFF
--- a/cli_flags.go
+++ b/cli_flags.go
@@ -51,7 +51,6 @@ type arguments struct {
 	pprofPrefix             string
 	sendErrorFrames         bool
 	serviceName             string
-	serviceVersion          string
 	environment             string
 	uploadSymbols           bool
 	uploadDynamicSymbols    bool
@@ -73,7 +72,7 @@ func parseArgs() (*arguments, error) {
 	versionInfo := version.GetVersionInfo()
 
 	cli.VersionPrinter = func(_ *cli.Command) {
-		fmt.Printf("dd-otel-host-profiler, version %s (revision: %s, date: %s), arch: %v\n",
+		fmt.Printf("dd-otel-host-profiler, version v%s (revision: %s, date: %s), arch: %v\n",
 			versionInfo.Version, versionInfo.VcsRevision, versionInfo.VcsTime, runtime.GOARCH)
 	}
 

--- a/helpers.go
+++ b/helpers.go
@@ -55,9 +55,6 @@ func addTagsFromArgs(tags *reporter.Tags, args *arguments) {
 	if args.serviceName != "" {
 		*tags = append(*tags, reporter.MakeTag("service", args.serviceName))
 	}
-	if args.serviceVersion != "" {
-		*tags = append(*tags, reporter.MakeTag("version", args.serviceVersion))
-	}
 }
 
 // isAPIKeyValid reports whether the given string is a structurally valid API key

--- a/main.go
+++ b/main.go
@@ -137,7 +137,7 @@ func mainWithExitCode() exitCode {
 		unix.SIGINT, unix.SIGTERM, unix.SIGABRT)
 	defer mainCancel()
 
-	log.Infof("Starting Datadog OTEL host profiler %s (revision: %s, date: %s), arch: %v",
+	log.Infof("Starting Datadog OTEL host profiler v%s (revision: %s, date: %s), arch: %v",
 		versionInfo.Version, versionInfo.VcsRevision, versionInfo.VcsTime, runtime.GOARCH)
 
 	if err = tracer.ProbeBPFSyscall(); err != nil {
@@ -214,7 +214,7 @@ func mainWithExitCode() exitCode {
 			APIKey:               args.apiKey,
 			APPKey:               args.appKey,
 			Site:                 args.site,
-			Version:              args.serviceVersion,
+			Version:              versionInfo.Version,
 		},
 	}, containerMetadataProvider)
 	if err != nil {

--- a/version/version.go
+++ b/version/version.go
@@ -5,7 +5,10 @@
 
 package version
 
-import "runtime/debug"
+import (
+	"runtime/debug"
+	"strings"
+)
 
 var (
 	// Version is the current version of the profiler
@@ -22,7 +25,7 @@ type Info struct {
 func GetVersionInfo() Info {
 	buildInfo, ok := debug.ReadBuildInfo()
 	versionInfo := Info{
-		Version: version,
+		Version: strings.TrimLeft(version, "v"),
 	}
 
 	if !ok {


### PR DESCRIPTION
# What does this PR do?

Service version was incorrectly being used for the profiler version when uploading symbols.
This change removes service version as it was not used anywhere else and use profiler version instead.
It also removes the "v" prefix from the profiler version.
