### PR TITLE
containermetadata: use full pod name

### DIFF
--- a/containermetadata/containermetadata_test.go
+++ b/containermetadata/containermetadata_test.go
@@ -235,7 +235,7 @@ func TestGetKubernetesPodMetadata(t *testing.T) {
 			pid:              1,
 			expContainerID:   "ed89697807a981b82f6245ac3a13be232c1e13435d52bc3f53060d61babe1997",
 			expContainerName: "testcontainer-ab1c",
-			expPodName:       "testpod",
+			expPodName:       "testpod-abc123-sldfj293",
 		},
 		{
 			name: "matchingPodNotFound",


### PR DESCRIPTION
# What does this PR do?

Use full pod name for container metadata

# Motivation

Previously, the logic would truncate the replicaset and pod hash from the pod name, showing the deployment name instead. this doesn't let users easily distinguish between two pods from the same replicaset running on the same node.

# Additional Notes

N/A

# How to test the change?

N/A
