### PR TITLE
[PROF-11308] feat: Batch requests to symbol-query API endpoint

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -39,6 +39,7 @@ import,github.com/google/gofuzz,Apache-2.0,unknown
 import,github.com/google/pprof/profile,Apache-2.0,unknown
 import,github.com/google/uuid,BSD-3-Clause,"Copyright (c) 2009,2014 Google Inc. All rights reserved."
 import,github.com/grpc-ecosystem/grpc-gateway/v2,BSD-3-Clause,"Copyright (c) 2015, Gengo, Inc."
+import,github.com/jonboulle/clockwork,Apache-2.0,unknown
 import,github.com/josharian/intern,MIT,Copyright (c) 2019 Josh Bleecher Snyder
 import,github.com/json-iterator/go,MIT,Copyright (c) 2016 json-iterator
 import,github.com/klauspost/compress,MIT,Copyright (c) 2012 The Go Authors. All rights reserved. | Copyright (c) 2019 Klaus Post. All rights reserved. | Copyright 2016-2017 The New York Times Company | Copyright (c) 2015 Klaus Post | Copyright (c) 2011 The Snappy-Go Authors. All rights reserved. | Copyright 2016 The filepathx Authors

--- a/cli_flags.go
+++ b/cli_flags.go
@@ -28,6 +28,7 @@ const (
 	defaultClockSyncInterval      = 3 * time.Minute
 	defaultProbabilisticThreshold = tracer.ProbabilisticThresholdMax
 	defaultProbabilisticInterval  = 1 * time.Minute
+	defaultSymbolQueryInterval    = 5 * time.Second
 	defaultArgSendErrorFrames     = false
 	defaultArgAgentURL            = "http://localhost:8126"
 
@@ -54,6 +55,7 @@ type arguments struct {
 	sendErrorFrames           bool
 	serviceName               string
 	environment               string
+	uploadSymbolQueryInterval time.Duration
 	uploadSymbols             bool
 	uploadDynamicSymbols      bool
 	uploadGoPCLnTab           bool
@@ -346,6 +348,14 @@ func parseArgs() (*arguments, error) {
 				Usage:       "Enable self-profiling with Go runtime profiler.",
 				Destination: &args.enableGoRuntimeProfiler,
 				Sources:     cli.EnvVars("DD_HOST_PROFILING_RUNTIME_PROFILER"),
+			},
+			&cli.DurationFlag{
+				Name:        "symbol-query-interval",
+				Value:       defaultSymbolQueryInterval,
+				Hidden:      true,
+				Usage:       "Symbol query interval (queries during a period are batched, 0 means no batching).",
+				Destination: &args.uploadSymbolQueryInterval,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_SYMBOL_QUERY_INTERVAL"),
 			},
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,8 @@ require (
 	k8s.io/client-go v0.31.3
 )
 
+require github.com/jonboulle/clockwork v0.5.0
+
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0 // indirect
@@ -62,6 +64,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
+	github.com/jarcoal/httpmock v1.3.1
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,10 @@ github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 h1:kes8mmyCpxJsI7FTwtzRqEy9
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.2/go.mod h1:Gou2R9+il93BqX25LAKCLuM+y9U2T4hlwvT1yprcna4=
 github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
+github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
+github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
+github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
+github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=
@@ -207,6 +211,8 @@ github.com/lufia/plan9stats v0.0.0-20220913051719-115f729f3c8c h1:VtwQ41oftZwlMn
 github.com/lufia/plan9stats v0.0.0-20220913051719-115f729f3c8c/go.mod h1:JKx41uQRwqlTZabZc+kILPrO/3jlKnQ2Z8b7YiVw5cE=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
+github.com/maxatome/go-testdeep v1.12.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/mdlayher/netlink v1.7.2 h1:/UtM3ofJap7Vl4QWCPDGXY8d3GIY2UGSDbK+QWmY8/g=
 github.com/mdlayher/netlink v1.7.2/go.mod h1:xraEF7uJbxLhc5fpHL4cPe221LI2bdttWlU+ZGLfQSw=
 github.com/mdlayher/socket v0.4.1 h1:eM9y2/jlbs1M615oshPQOHZzj6R6wMT7bX5NPiQvn2U=

--- a/main.go
+++ b/main.go
@@ -220,6 +220,7 @@ func mainWithExitCode() exitCode {
 			Enabled:              args.uploadSymbols,
 			UploadDynamicSymbols: args.uploadDynamicSymbols,
 			UploadGoPCLnTab:      args.uploadGoPCLnTab,
+			SymbolQueryInterval:  args.uploadSymbolQueryInterval,
 			DryRun:               args.uploadSymbolsDryRun,
 			SymbolEndpoints:      symbolEndpoints,
 			Version:              versionInfo.Version,

--- a/reporter/config.go
+++ b/reporter/config.go
@@ -57,6 +57,8 @@ type SymbolUploaderConfig struct {
 	UploadDynamicSymbols bool
 	// UploadGoPCLnTab defines whether the agent should upload GoPCLnTab section for Go binaries to the backend.
 	UploadGoPCLnTab bool
+	// BatchSymbolQueries defines whether the uploader should batch symbol queries.
+	SymbolQueryInterval time.Duration
 	// DryRun defines whether the agent should upload debug symbols to the backend in dry-run mode.
 	DryRun bool
 	// Sites to upload symbols to.

--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -346,9 +346,11 @@ func (r *DatadogReporter) Start(mainCtx context.Context) error {
 	ctx, cancelReporting := context.WithCancel(mainCtx)
 
 	if r.symbolUploader != nil {
-		go func() {
-			r.symbolUploader.Run(ctx)
-		}()
+		err := r.symbolUploader.Start(ctx)
+		if err != nil {
+			cancelReporting()
+			return err
+		}
 	}
 
 	go func() {

--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -345,13 +345,7 @@ func (r *DatadogReporter) Start(mainCtx context.Context) error {
 	// Create a child context for reporting features
 	ctx, cancelReporting := context.WithCancel(mainCtx)
 
-	if r.symbolUploader != nil {
-		err := r.symbolUploader.Start(ctx)
-		if err != nil {
-			cancelReporting()
-			return err
-		}
-	}
+	r.symbolUploader.Start(ctx)
 
 	go func() {
 		tick := time.NewTicker(r.config.ReportInterval)

--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -345,7 +345,9 @@ func (r *DatadogReporter) Start(mainCtx context.Context) error {
 	// Create a child context for reporting features
 	ctx, cancelReporting := context.WithCancel(mainCtx)
 
-	r.symbolUploader.Start(ctx)
+	if r.symbolUploader != nil {
+		r.symbolUploader.Start(ctx)
+	}
 
 	go func() {
 		tick := time.NewTicker(r.config.ReportInterval)

--- a/reporter/pipeline/pipeline.go
+++ b/reporter/pipeline/pipeline.go
@@ -1,0 +1,270 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+)
+
+type Stage interface {
+	Start(ctx context.Context)
+	Stop()
+	Connect(next Stage) error
+	SetConcurrency(concurrency int)
+	SetOutputChanSize(size int)
+}
+
+type Pipeline interface {
+	Start(ctx context.Context)
+	Stop()
+}
+
+type Consumer[In any] interface {
+	SetInputChannel(chan In)
+}
+
+var _ Stage = (*StageWorker[any, any])(nil)
+var _ Consumer[any] = (*StageWorker[any, any])(nil)
+
+type baseWorker[In any, Out any] struct {
+	wg          sync.WaitGroup
+	inputChan   <-chan In
+	outputChan  chan Out
+	concurrency int
+}
+
+type StageWorker[In any, Out any] struct {
+	baseWorker[In, Out]
+	processingFunc func(context.Context, In) []Out
+}
+
+type BatchingStageWorker[In any] struct {
+	baseWorker[In, []In]
+	batchSize     int
+	batchInterval time.Duration
+	clock         clockwork.Clock
+}
+
+type nullOutput struct{}
+
+func NewStage[In any, Out any](fun func(context.Context, In) []Out) *StageWorker[In, Out] {
+	output := make(chan Out)
+	return &StageWorker[In, Out]{
+		baseWorker: baseWorker[In, Out]{
+			outputChan:  output,
+			concurrency: 1,
+		},
+		processingFunc: fun,
+	}
+}
+
+func NewSinkStage[In any](fun func(context.Context, In)) *StageWorker[In, nullOutput] {
+	return &StageWorker[In, nullOutput]{
+		baseWorker: baseWorker[In, nullOutput]{
+			outputChan:  nil,
+			concurrency: 1,
+		},
+		processingFunc: func(ctx context.Context, input In) []nullOutput {
+			fun(ctx, input)
+			return nil
+		},
+	}
+}
+
+func NewBatchingStage[In any](batchInterval time.Duration, batchSize int) *BatchingStageWorker[In] {
+	return NewBatchingStageWithClock[In](batchInterval, batchSize, clockwork.NewRealClock())
+}
+
+func NewBatchingStageWithClock[In any](batchInterval time.Duration, batchSize int, clock clockwork.Clock) *BatchingStageWorker[In] {
+	output := make(chan []In)
+	return &BatchingStageWorker[In]{
+		baseWorker: baseWorker[In, []In]{
+			outputChan:  output,
+			concurrency: 1,
+		},
+		batchSize:     batchSize,
+		batchInterval: batchInterval,
+		clock:         clock,
+	}
+}
+
+func (w *StageWorker[In, Out]) Start(ctx context.Context) {
+	for range w.concurrency {
+		w.wg.Add(1)
+		go func() {
+			defer w.wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case input, ok := <-w.inputChan:
+					if !ok {
+						return
+					}
+					for _, output := range w.processingFunc(ctx, input) {
+						w.outputChan <- output
+					}
+				}
+			}
+		}()
+	}
+}
+
+func (w *baseWorker[In, Out]) Stop() {
+	if w.outputChan != nil {
+		defer close(w.outputChan)
+	}
+	w.wg.Wait()
+}
+
+func (w *baseWorker[In, Out]) SetInputChannel(inputChan chan In) {
+	w.inputChan = inputChan
+}
+
+func (w *baseWorker[In, Out]) SetConcurrency(concurrency int) {
+	w.concurrency = concurrency
+}
+
+func (w *baseWorker[In, Out]) SetOutputChanSize(size int) {
+	w.outputChan = make(chan Out, size)
+}
+
+func (w *baseWorker[In, Out]) Connect(next Stage) error {
+	if w.outputChan == nil {
+		return errors.New("cannot connect sink stage")
+	}
+	w2, ok := next.(Consumer[Out])
+	if !ok {
+		return fmt.Errorf("cannot connect stage %T to %T", w, next)
+	}
+
+	w2.SetInputChannel(w.outputChan)
+	return nil
+}
+
+func (w *BatchingStageWorker[In]) Start(ctx context.Context) {
+	for range w.concurrency {
+		w.wg.Add(1)
+		go func() {
+			defer w.wg.Done()
+			var batch []In
+			var tickerChan <-chan time.Time
+			if w.batchInterval > 0 {
+				tickerChan = w.clock.NewTicker(w.batchInterval).Chan()
+			}
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case input, ok := <-w.inputChan:
+					if !ok {
+						if len(batch) > 0 {
+							w.outputChan <- batch
+						}
+						return
+					}
+					batch = append(batch, input)
+					if w.batchSize > 0 && len(batch) >= w.batchSize {
+						w.outputChan <- batch
+						batch = nil
+					}
+				case <-tickerChan:
+					if len(batch) > 0 {
+						w.outputChan <- batch
+						batch = nil
+					}
+				}
+			}
+		}()
+	}
+}
+
+type pipeline[In any] struct {
+	workers   []Stage
+	inputChan chan In
+}
+
+func (p *pipeline[In]) Start(ctx context.Context) {
+	for _, worker := range p.workers {
+		worker.Start(ctx)
+	}
+}
+
+func (p *pipeline[In]) Stop() {
+	close(p.inputChan)
+	for _, worker := range p.workers {
+		worker.Stop()
+	}
+}
+
+type Builder interface {
+	AddStage(stage Stage, options ...StageOption) Builder
+	Build() (Pipeline, error)
+}
+
+type pipelineBuilder[In any] struct {
+	workers   []Stage
+	inputChan chan In
+}
+
+func NewPipelineBuilder[In any](inputChan chan In) Builder {
+	return &pipelineBuilder[In]{
+		inputChan: inputChan,
+	}
+}
+
+func (b *pipelineBuilder[In]) AddStage(stage Stage, options ...StageOption) Builder {
+	b.workers = append(b.workers, stage)
+	for _, option := range options {
+		option(stage)
+	}
+	return b
+}
+
+func (b *pipelineBuilder[In]) Build() (Pipeline, error) {
+	if len(b.workers) == 0 {
+		return &pipeline[In]{
+			workers:   nil,
+			inputChan: b.inputChan,
+		}, nil
+	}
+
+	w := b.workers[0]
+	w2, ok := w.(Consumer[In])
+	if !ok {
+		return nil, fmt.Errorf("first stage %T must accept input %T", w, b.inputChan)
+	}
+	w2.SetInputChannel(b.inputChan)
+	for i, worker := range b.workers[1:] {
+		if err := b.workers[i].Connect(worker); err != nil {
+			return nil, fmt.Errorf("cannot connect stage %d to stage %d: %w", i, i+1, err)
+		}
+	}
+	return &pipeline[In]{
+		workers:   b.workers,
+		inputChan: b.inputChan,
+	}, nil
+}
+
+type StageOption func(Stage)
+
+func WithConcurrency(concurrency int) StageOption {
+	return func(s Stage) {
+		s.SetConcurrency(concurrency)
+	}
+}
+
+func WithOutputChanSize(size int) StageOption {
+	return func(s Stage) {
+		s.SetOutputChanSize(size)
+	}
+}

--- a/reporter/symbol/elf.go
+++ b/reporter/symbol/elf.go
@@ -30,6 +30,7 @@ type Elf struct {
 	gnuBuildID string
 	fileHash   string
 	path       string
+	fileID     libpf.FileID
 
 	separateSymbols *elfWrapperWithSource
 
@@ -55,6 +56,7 @@ func NewElf(path string, fileID libpf.FileID, opener process.FileOpener) (*Elf, 
 		isGolang: wrapper.elfFile.IsGolang(),
 		path:     path,
 		fileHash: fileID.StringNoQuotes(),
+		fileID:   fileID,
 	}
 
 	buildID, err := wrapper.elfFile.GetBuildID()
@@ -90,6 +92,10 @@ func NewElf(path string, fileID libpf.FileID, opener process.FileOpener) (*Elf, 
 
 func (e *Elf) FileHash() string {
 	return e.fileHash
+}
+
+func (e *Elf) FileID() libpf.FileID {
+	return e.fileID
 }
 
 func (e *Elf) GnuBuildID() string {
@@ -170,4 +176,13 @@ func (e *Elf) String() string {
 	return fmt.Sprintf("%s, arch=%s, gnu_build_id=%s, go_build_id=%s, file_hash=%s, symbol_source=%s, has_gopclntab=%t",
 		e.path, e.arch, e.gnuBuildID, e.goBuildID, e.fileHash, symbolSource, hasPCLnTab,
 	)
+}
+
+func NewElfForTest(arch, gnuBuildID, goBuildID, fileHash string) *Elf {
+	return &Elf{
+		arch:       arch,
+		gnuBuildID: gnuBuildID,
+		goBuildID:  goBuildID,
+		fileHash:   fileHash,
+	}
 }

--- a/reporter/symbol_query_batching.go
+++ b/reporter/symbol_query_batching.go
@@ -1,0 +1,137 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package reporter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/DataDog/dd-otel-host-profiler/reporter/symbol"
+)
+
+type SymbolQueryBatch []*symbol.Elf
+
+type SymbolQueryResult struct {
+	SymbolSource symbol.Source
+	Err          error
+}
+
+type ElfWithBackendSources struct {
+	*symbol.Elf
+	BackendSymbolSources []SymbolQueryResult
+}
+
+func invokeQuerier(ctx context.Context, buildIDs []string, arch string, querier SymbolQuerier, ind int,
+	buildIDToResult map[string][]*ElfWithBackendSources) {
+	symbolFiles, err := querier.QuerySymbols(ctx, buildIDs, arch)
+	if err != nil {
+		for _, results := range buildIDToResult {
+			for _, result := range results {
+				result.BackendSymbolSources[ind].Err = fmt.Errorf("failed to query symbols: %w", err)
+			}
+		}
+		return
+	}
+
+	// Note that the same buildID can appear multiple times in the symbolFiles with different buildIDTypes
+	// because there is no constraint in sourcemap DB that prevents having identical goBuildID, gnuBuildID
+	// of fileHash for the same or a different executable.
+	// For a given buildID though, the backend will return first the matching gnuBuildID, then goBuildID and
+	// finally fileHash if they exist.
+	// That's why we consider the first symbol source for a given buildID and ignore the rest.
+	for _, symbolFile := range symbolFiles {
+		for _, result := range buildIDToResult[symbolFile.BuildID] {
+			queryResult := &result.BackendSymbolSources[ind]
+			if queryResult.Err != nil || queryResult.SymbolSource != symbol.SourceNone {
+				// Already set or an error occurred, skips
+				continue
+			}
+			src, err := symbol.NewSource(symbolFile.SymbolSource)
+			if err != nil {
+				result.BackendSymbolSources[ind].Err = fmt.Errorf("failed to parse symbol source: %w", err)
+			} else {
+				result.BackendSymbolSources[ind].SymbolSource = src
+			}
+		}
+	}
+}
+
+func (e *ElfWithBackendSources) fillWithError(err error) {
+	for i := range e.BackendSymbolSources {
+		e.BackendSymbolSources[i].Err = err
+	}
+}
+
+func getBuildID(e *symbol.Elf) string {
+	// Only consider the first non-empty buildID between gnuBuildID, goBuildID and fileHash
+	// This simplifies the logic and profile will contain only this buildID anyway.
+	buildID := e.GnuBuildID()
+	if buildID != "" {
+		return buildID
+	}
+	buildID = e.GoBuildID()
+	if buildID != "" {
+		return buildID
+	}
+	return e.FileHash()
+}
+
+func ExecuteSymbolQueryBatch(ctx context.Context, batch SymbolQueryBatch, queriers []SymbolQuerier) []ElfWithBackendSources {
+	if len(batch) == 0 {
+		return nil
+	}
+
+	log.Infof("Querying symbols for %d executables", len(batch))
+	buildIDToResult := make(map[string][]*ElfWithBackendSources)
+
+	// All the elfs in the batch are expected to have the same arch
+	arch := batch[0].Arch()
+
+	elfResults := make([]ElfWithBackendSources, 0, len(batch))
+
+	for _, e := range batch {
+		elfResults = append(elfResults,
+			ElfWithBackendSources{Elf: e, BackendSymbolSources: make([]SymbolQueryResult, len(queriers))})
+
+		result := &elfResults[len(elfResults)-1]
+		if e.Arch() != arch {
+			result.fillWithError(fmt.Errorf("arch mismatch: expected %s, got %s", arch, e.Arch()))
+			continue
+		}
+
+		buildID := getBuildID(e)
+		if buildID == "" {
+			result.fillWithError(errors.New("empty buildID"))
+			continue
+		}
+		buildIDToResult[buildID] = append(buildIDToResult[buildID], result)
+	}
+
+	buildIDs := make([]string, 0, len(buildIDToResult))
+	for buildID := range buildIDToResult {
+		buildIDs = append(buildIDs, buildID)
+	}
+
+	if len(queriers) == 1 {
+		invokeQuerier(ctx, buildIDs, arch, queriers[0], 0, buildIDToResult)
+	} else {
+		var wg sync.WaitGroup
+		for i, querier := range queriers {
+			wg.Add(1)
+			go func(i int, querier SymbolQuerier) {
+				defer wg.Done()
+				invokeQuerier(ctx, buildIDs, arch, querier, i, buildIDToResult)
+			}(i, querier)
+		}
+		wg.Wait()
+	}
+
+	return elfResults
+}

--- a/reporter/symbol_query_batching_test.go
+++ b/reporter/symbol_query_batching_test.go
@@ -1,0 +1,195 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package reporter
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/dd-otel-host-profiler/reporter/symbol"
+)
+
+type key struct {
+	buildID string
+	arch    string
+}
+
+type value struct {
+	symbolSource string
+	buildIDType  string
+}
+
+type symbolMap map[key][]value
+type errorMap map[string]error
+
+type mockSymbolQuerier struct {
+	m      symbolMap
+	e      errorMap
+	ncalls int
+}
+
+func (m *mockSymbolQuerier) QuerySymbols(_ context.Context, buildIDs []string, arch string) ([]SymbolFile, error) {
+	m.ncalls++
+	if err, ok := m.e[arch]; ok {
+		return nil, err
+	}
+
+	buildIDsCopy := make([]string, len(buildIDs))
+	copy(buildIDsCopy, buildIDs)
+
+	// randomly shuffle the buildIDWs
+	for i := range buildIDsCopy {
+		j := rand.Intn(i + 1) //nolint:gosec
+		buildIDsCopy[i], buildIDsCopy[j] = buildIDsCopy[j], buildIDsCopy[i]
+	}
+
+	var symbolFiles []SymbolFile
+	for _, buildID := range buildIDsCopy {
+		if values, ok := m.m[key{buildID, arch}]; ok {
+			for _, s := range values {
+				symbolFiles = append(symbolFiles, SymbolFile{
+					BuildID:      buildID,
+					SymbolSource: s.symbolSource,
+					BuildIDType:  s.buildIDType,
+				})
+			}
+		}
+	}
+
+	return symbolFiles, nil
+}
+
+func newTestQuerier1() *mockSymbolQuerier {
+	e := errorMap{"arch0": errors.New("error")}
+
+	m := symbolMap{
+		{buildID: "buildid1", arch: "arch1"}: []value{{symbolSource: "symbol_table", buildIDType: "gnu_build_id"}},
+		{buildID: "buildid2", arch: "arch1"}: []value{
+			{symbolSource: "symbol_table", buildIDType: "gnu_build_id"},
+			{symbolSource: "debug_info", buildIDType: "go_build_id"}},
+		{buildID: "buildid1", arch: "arch2"}: []value{{symbolSource: "debug_info", buildIDType: "gnu_build_id"}},
+	}
+
+	return &mockSymbolQuerier{m: m, e: e}
+}
+
+func newTestQuerier2() *mockSymbolQuerier {
+	e := errorMap{
+		"arch0": errors.New("error"),
+		"arch2": errors.New("error")}
+
+	m := symbolMap{
+		{buildID: "buildid1", arch: "arch1"}: []value{{symbolSource: "debug_info", buildIDType: "gnu_build_id"}},
+	}
+
+	return &mockSymbolQuerier{m: m, e: e}
+}
+
+func TestBatchSymbolQuerier_Multiplexing(t *testing.T) {
+	querier1 := newTestQuerier1()
+	querier2 := newTestQuerier2()
+
+	queriers := []SymbolQuerier{querier1, querier2}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Run("Empty batch", func(t *testing.T) {
+		results := ExecuteSymbolQueryBatch(ctx, nil, queriers)
+		require.Empty(t, results)
+	})
+
+	t.Run("Multiple buildIDs", func(t *testing.T) {
+		elfs := []*symbol.Elf{
+			symbol.NewElfForTest("arch1", "non_existing_buildid", "", ""),
+			symbol.NewElfForTest("arch1", "buildid1", "buildid2", ""), // multiple buildIDs, gnu_build_id should be used
+			symbol.NewElfForTest("arch2", "buildid1", "", ""),         // arch mismatch
+			symbol.NewElfForTest("arch1", "", "", ""),                 // empty buildID
+			symbol.NewElfForTest("arch1", "buildid2", "", ""),         // multiple matching buildIDs, first one should be used
+		}
+		results := ExecuteSymbolQueryBatch(ctx, elfs, queriers)
+		require.ElementsMatch(t, []ElfWithBackendSources{
+			{
+				Elf: elfs[0],
+				BackendSymbolSources: []SymbolQueryResult{
+					{
+						SymbolSource: symbol.SourceNone,
+					},
+					{
+						SymbolSource: symbol.SourceNone,
+					},
+				},
+			},
+			{
+				Elf: elfs[1],
+				BackendSymbolSources: []SymbolQueryResult{
+					{
+						SymbolSource: symbol.SourceSymbolTable,
+					},
+					{
+						SymbolSource: symbol.SourceDebugInfo,
+					},
+				},
+			},
+			{
+				Elf: elfs[2],
+				BackendSymbolSources: []SymbolQueryResult{
+					{
+						Err: errors.New("arch mismatch: expected arch1, got arch2"),
+					},
+					{
+						Err: errors.New("arch mismatch: expected arch1, got arch2"),
+					},
+				},
+			},
+			{
+				Elf: elfs[3],
+				BackendSymbolSources: []SymbolQueryResult{
+					{
+						Err: errors.New("empty buildID"),
+					},
+					{
+						Err: errors.New("empty buildID"),
+					},
+				},
+			},
+			{
+				Elf: elfs[4],
+				BackendSymbolSources: []SymbolQueryResult{
+					{ // multiple matching buildIDs, first one should be used
+						SymbolSource: symbol.SourceSymbolTable,
+					},
+					{
+						SymbolSource: symbol.SourceNone,
+					},
+				},
+			},
+		}, results)
+	})
+
+	t.Run("Errors on both endpoints", func(t *testing.T) {
+		elfs := []*symbol.Elf{
+			symbol.NewElfForTest("arch0", "buildid1", "", ""),
+		}
+		results := ExecuteSymbolQueryBatch(ctx, elfs, queriers)
+		require.Error(t, results[0].BackendSymbolSources[0].Err)
+		require.Error(t, results[0].BackendSymbolSources[1].Err)
+	})
+
+	t.Run("Errors on one endpoint", func(t *testing.T) {
+		elfs := []*symbol.Elf{
+			symbol.NewElfForTest("arch2", "buildid1", "", ""),
+		}
+		results := ExecuteSymbolQueryBatch(ctx, elfs, queriers)
+		require.Error(t, results[0].BackendSymbolSources[1].Err)
+		require.NoError(t, results[0].BackendSymbolSources[0].Err)
+		require.Equal(t, symbol.SourceDebugInfo, results[0].BackendSymbolSources[0].SymbolSource)
+	})
+}

--- a/reporter/symbol_query_batching_test.go
+++ b/reporter/symbol_query_batching_test.go
@@ -44,7 +44,7 @@ func (m *mockSymbolQuerier) QuerySymbols(_ context.Context, buildIDs []string, a
 	buildIDsCopy := make([]string, len(buildIDs))
 	copy(buildIDsCopy, buildIDs)
 
-	// randomly shuffle the buildIDWs
+	// randomly shuffle the buildIDs
 	for i := range buildIDsCopy {
 		j := rand.Intn(i + 1) //nolint:gosec
 		buildIDsCopy[i], buildIDsCopy[j] = buildIDsCopy[j], buildIDsCopy[i]

--- a/reporter/symbol_uploader_test.go
+++ b/reporter/symbol_uploader_test.go
@@ -208,7 +208,7 @@ func TestSymbolUpload(t *testing.T) {
 	t.Run("No upload when no symbols", func(t *testing.T) {
 		uploader, err := newTestUploader(false, false)
 		require.NoError(t, err)
-		require.NoError(t, uploader.Start(context.Background()))
+		uploader.Start(context.Background())
 
 		uploader.UploadSymbols(libpf.FileID{}, exe, "build_id", &DummyOpener{})
 		uploader.Stop()
@@ -221,7 +221,7 @@ func TestSymbolUpload(t *testing.T) {
 		defer cancel()
 		uploader, err := newTestUploader(false, true)
 		require.NoError(t, err)
-		require.NoError(t, uploader.Start(ctx))
+		uploader.Start(ctx)
 		uploader.UploadSymbols(libpf.FileID{}, exe, "build_id", &DummyOpener{})
 		req := <-c
 		checkRequest(t, req)


### PR DESCRIPTION
# What does this PR do?

Batch requests to symbol-query API endpoint.

# Motivation

Avoid being rate limited by endpoint.

# Additional Notes

This change introduces `BatchSymbolQuerier` which implements a `QuerySymbols` method that blocks until the request is completed.
`QuerySymbols` pushes query into a synchronous channel and then waits on a `done` channel . Internally `BatchSymbolQuerier` has a single worker goroutine that fetches queries from channel and stores them in an array. Batch call is done at regular time intervals.

Also fixes symbol upload for vdso: vdso does not have a file associated to it (its path is empty), hence we need to dump its content to disk to be able to upload it.

# How to test the change?
