### PR TITLE
Bump go version to 1.23.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.1-bookworm@sha256:dba79eb312528369dea87532a65dbe9d4efb26439a0feacc9e7ac9b0f1c7f607
+FROM golang:1.23.6-bookworm@sha256:441f59f8a2104b99320e1f5aaf59a81baabbc36c81f4e792d5715ef09dd29355
 
 RUN apt-get update -y && apt-get upgrade -y && apt-get install -y sudo && apt-get clean autoclean && apt-get autoremove --yes 
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ To enable local symbol upload:
 3. Provide a Datadog APP key through the `DD_APP_KEY` environment variable.
 4. Set the `DD_SITE` environment variable to [your Datadog site](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site) (e.g. `datadoghq.com`, `datadoghq.eu`, `us5.datadoghq.com`, ...).
 
+## Build 
+
+You must first ensure you have the correct version of go installed.
+In order to build the profiler directly on your machine, you can simply run:
+
+```
+make
+```
+
 ## Development
 
 A `docker-compose.yml` file is provided to help run the profiler in a container for local development.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/dd-otel-host-profiler
 
-go 1.23.1
+go 1.23.6
 
 require (
 	github.com/DataDog/jsonapi v0.10.0


### PR DESCRIPTION
# What does this PR do?

Bumps go to version 1.23.6.

# Motivation

It is generally good practice to stay as up-to-date as possible on go releases.

# Additional Notes

We could not bump to the latest version (1.24.0) because the corresponding Docker image is not yet available.

# How to test the change?

Simply check that the project still builds and that there is no regression. You can do that by using `make` and `make test`. You can also check that the project builds successfully in the docker image by running `make profiler-in-docker`.
