### PR TITLE
Enable debug tracing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 VERSION ?= v0.0.0
 VERSION_LD_FLAGS := -X github.com/DataDog/dd-otel-host-profiler/version.version=$(VERSION)
-GO_FLAGS := -ldflags="${VERSION_LD_FLAGS} -extldflags=-static" -tags osusergo,netgo 
+GO_FLAGS := -ldflags="${VERSION_LD_FLAGS} -extldflags=-static" -tags osusergo,netgo,debugtracer
 
 all: build
 

--- a/cli_flags.go
+++ b/cli_flags.go
@@ -62,6 +62,7 @@ type arguments struct {
 	timeline                  bool
 	tracers                   string
 	verboseMode               bool
+	verboseeBPF               bool
 	apiKey                    string
 	appKey                    string
 	site                      string
@@ -222,6 +223,13 @@ func parseArgs() (*arguments, error) {
 				Usage:       "Enable verbose logging and debugging capabilities.",
 				Destination: &args.verboseMode,
 				Sources:     cli.EnvVars("DD_HOST_PROFILING_VERBOSE"),
+			},
+			&cli.BoolFlag{
+				Name:        "verbose-ebpf",
+				Value:       false,
+				Usage:       "Enable verbose logging and debugging capabilities for eBPF.",
+				Destination: &args.verboseeBPF,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_VERBOSE_EBPF"),
 			},
 			&cli.StringFlag{
 				Name:        "pprof-prefix",

--- a/go.mod
+++ b/go.mod
@@ -124,4 +124,4 @@ require (
 // To update the Datadog/opentelemetry-ebpf-profiler dependency on latest commit on datadog branch, change the following line to:
 // replace github.com/open-telemetry/opentelemetry-ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler datadog
 // and run `GOPRIVATE=github.com/Datadog/* go mod tidy`
-replace go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20241121135249-b6ca36e82a06
+replace go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250226180854-ea618b05c65c

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/
 github.com/DataDog/gostackparse v0.7.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/DataDog/jsonapi v0.10.0 h1:qDNSVEdnNteT6lXg9xN/JaGNgvVphwmN8frtJVzUVEU=
 github.com/DataDog/jsonapi v0.10.0/go.mod h1:FUSGF3bwMARlVfXEoFo9R/CVlYYy9BGL4C/Prf6Ke3M=
-github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20241121135249-b6ca36e82a06 h1:n/86T7k33ex2SbJt8WnmnBBjpaQiqBRklmLy5YeBCms=
-github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20241121135249-b6ca36e82a06/go.mod h1:LZs0Ai6k5IPICeMqXRDpr1uyW7NJnoXgyrlaQh36XSM=
+github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250226180854-ea618b05c65c h1:tk8cvz7giQgErSP0bbkMYxTE8Cz/d9+9swfb/IdQVjc=
+github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250226180854-ea618b05c65c/go.mod h1:LZs0Ai6k5IPICeMqXRDpr1uyW7NJnoXgyrlaQh36XSM=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.20.0 h1:fKv05WFWHCXQmUTehW1eEZvXJP65Qv00W4V01B1EqSA=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.20.0/go.mod h1:dvIWN9pA2zWNTw5rhDWZgzZnhcfpH++d+8d1SWW6xkY=
 github.com/DataDog/sketches-go v1.4.5 h1:ki7VfeNz7IcNafq7yI/j5U/YCkO3LJiMDtXz9OMQbyE=


### PR DESCRIPTION
# What does this PR do?

1. Enables the use of the debug eBPF build by default.
2. Enables debug tracing through --verbose-ebpf, which also enables redirection of logs from trace_pipe to the log output.

# Motivation

It makes debugging require less configuration.

# Additional Notes

None.

# How to test the change?

Check that, when invoked with --verbose-ebpf, the profiler outputs ebpf logs.
Check that when invoked without that flag, nothing changes.
