### PR TITLE
enable nodejs profiling on arm64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,4 +127,4 @@ require (
 // To update the Datadog/opentelemetry-ebpf-profiler dependency on latest commit on datadog branch, change the following line to:
 // replace go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler datadog
 // and run `GOPRIVATE=github.com/Datadog/* go mod tidy`
-replace go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250228165629-3f5ed93c8408
+replace go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250312101446-72b55407d98e

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/
 github.com/DataDog/gostackparse v0.7.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/DataDog/jsonapi v0.10.0 h1:qDNSVEdnNteT6lXg9xN/JaGNgvVphwmN8frtJVzUVEU=
 github.com/DataDog/jsonapi v0.10.0/go.mod h1:FUSGF3bwMARlVfXEoFo9R/CVlYYy9BGL4C/Prf6Ke3M=
-github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250228165629-3f5ed93c8408 h1:lnRY5H37WfDZqj/IeRU7yRtZ9tzmaBi8ezn53oBGSn0=
-github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250228165629-3f5ed93c8408/go.mod h1:LZs0Ai6k5IPICeMqXRDpr1uyW7NJnoXgyrlaQh36XSM=
+github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250312101446-72b55407d98e h1:S3oAhWo5+njoAQajfLPMzCR0rxWdtW7/vwOsQNhe6Dw=
+github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250312101446-72b55407d98e/go.mod h1:LZs0Ai6k5IPICeMqXRDpr1uyW7NJnoXgyrlaQh36XSM=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.20.0 h1:fKv05WFWHCXQmUTehW1eEZvXJP65Qv00W4V01B1EqSA=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.20.0/go.mod h1:dvIWN9pA2zWNTw5rhDWZgzZnhcfpH++d+8d1SWW6xkY=
 github.com/DataDog/sketches-go v1.4.5 h1:ki7VfeNz7IcNafq7yI/j5U/YCkO3LJiMDtXz9OMQbyE=


### PR DESCRIPTION
# What does this PR do?

Uses an updated version of the ebpf profiler which can profile nodejs v16.0.0+ programs on arm64.

# How to test the change?

Run a nodejs program on an arm64 machine and observe the profile. You could compare it to the same program being profiled on amd64 for reference.
