### PR TITLE
Concurrent symbol upload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.21.0 // indirect
-	golang.org/x/sync v0.10.0 // indirect
+	golang.org/x/sync v0.10.0
 	golang.org/x/term v0.27.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.6.0 // indirect


### PR DESCRIPTION
# What does this PR do?

Make symbol uploads to different endpoints concurrent.

# Motivation

A lot of the work done for symbol upload was redundant (creation of symbol file, creation and compression of the request).
This PR makes sure that symbol file creation and building of request body is done once, and then fan out the upload part.
