### PR TITLE
uploader: always load ELF sections

### DIFF
--- a/reporter/symbol/elf_wrapper.go
+++ b/reporter/symbol/elf_wrapper.go
@@ -53,6 +53,11 @@ func openELF(filePath string, opener process.FileOpener) (*elfWrapper, error) {
 		_ = r.Close()
 		return nil, err
 	}
+	err = ef.LoadSections()
+	if err != nil {
+		_ = r.Close()
+		return nil, err
+	}
 	return &elfWrapper{reader: r, elfFile: ef, filePath: filePath, actualFilePath: actualFilePath, opener: opener}, nil
 }
 


### PR DESCRIPTION
# What does this PR do?

Always load ELF sections

# Motivation

Missing ELF sections would lead to `debug_info` not being detected.

# Additional Notes

N/A

# How to test the change?

N/A
