### PR TITLE
Add symbol uploader tests

### DIFF
--- a/pclntab/pclntab.go
+++ b/pclntab/pclntab.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"unsafe"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
@@ -373,7 +374,7 @@ func SearchGoPclntab(ef *pfelf.File) (data []byte, address uint64, err error) {
 		}
 	}
 
-	return nil, 0, nil
+	return nil, 0, errors.New("could not find .gopclntab with signature search")
 }
 
 func (g *GoPCLnTabInfo) findMaxInlineTreeOffset() int {
@@ -586,7 +587,7 @@ func findGoPCLnTab(ef *pfelf.File, additionalChecks bool) (goPCLnTabInfo *GoPCLn
 		// gopclntab parsing code might panic if the data is corrupt.
 		defer func() {
 			if r := recover(); r != nil {
-				err = fmt.Errorf("panic while searching pclntab: %v", r)
+				err = fmt.Errorf("panic while searching pclntab: %v, stack:\n%s", r, debug.Stack())
 			}
 		}()
 	}

--- a/pclntab/pclntab.go
+++ b/pclntab/pclntab.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"runtime/debug"
 	"unsafe"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
@@ -587,7 +586,7 @@ func findGoPCLnTab(ef *pfelf.File, additionalChecks bool) (goPCLnTabInfo *GoPCLn
 		// gopclntab parsing code might panic if the data is corrupt.
 		defer func() {
 			if r := recover(); r != nil {
-				err = fmt.Errorf("panic while searching pclntab: %v, stack:\n%s", r, debug.Stack())
+				err = fmt.Errorf("panic while searching pclntab: %v", r)
 			}
 		}()
 	}


### PR DESCRIPTION
# What does this PR do?

Add various test cases for symbol uploader.
Fix wrong symbol source when uploading Go binary with an error during pclntab extraction.