### PR TITLE
fix: ensure sites are not duplicated

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,6 +83,16 @@ func startTraceHandling(ctx context.Context, rep otelreporter.TraceReporter,
 	return err
 }
 
+func appendEndpoint(symbolEndpoints []reporter.SymbolEndpoint, site, apiKey, appKey string) []reporter.SymbolEndpoint {
+	// Ensure this exact endpoint has not already been added.
+	for _, endpoint := range symbolEndpoints {
+		if site == endpoint.Site && apiKey == endpoint.APIKey && appKey == endpoint.AppKey {
+			return symbolEndpoints
+		}
+	}
+	return append(symbolEndpoints, reporter.SymbolEndpoint{Site: site, APIKey: apiKey, AppKey: appKey})
+}
+
 func main() {
 	os.Exit(int(mainWithExitCode()))
 }
@@ -182,7 +192,7 @@ func mainWithExitCode() exitCode {
 	var symbolEndpoints = args.additionalSymbolEndpoints
 
 	if args.site != "" && args.apiKey != "" && args.appKey != "" {
-		symbolEndpoints = append(symbolEndpoints, reporter.SymbolEndpoint{Site: args.site, APIKey: args.apiKey, AppKey: args.appKey})
+		symbolEndpoints = appendEndpoint(symbolEndpoints, args.site, args.apiKey, args.appKey)
 	}
 
 	var intakeURL string


### PR DESCRIPTION

# What does this PR do?
We were not checking whether DD_SITE, DD_API_KEY and DD_APP_KEY were already present in the list of additional endpoints.
Therefore, if by mistake DD_SITE (along with APP/API keys) are exactly the same as a site added in DD_HOST_PROFILING_ADDITIONAL_SYMBOL_ENDPOINTS,  profiles and symbols would be sent twice to the agent.
