### PR TITLE
reporter: move build id detection logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,4 +127,4 @@ require (
 // To update the Datadog/opentelemetry-ebpf-profiler dependency on latest commit on datadog branch, change the following line to:
 // replace go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler datadog
 // and run `GOPRIVATE=github.com/Datadog/* go mod tidy`
-replace go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250312101446-72b55407d98e
+replace go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250416145457-bc718b64c214

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/
 github.com/DataDog/gostackparse v0.7.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/DataDog/jsonapi v0.10.0 h1:qDNSVEdnNteT6lXg9xN/JaGNgvVphwmN8frtJVzUVEU=
 github.com/DataDog/jsonapi v0.10.0/go.mod h1:FUSGF3bwMARlVfXEoFo9R/CVlYYy9BGL4C/Prf6Ke3M=
-github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250312101446-72b55407d98e h1:S3oAhWo5+njoAQajfLPMzCR0rxWdtW7/vwOsQNhe6Dw=
-github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250312101446-72b55407d98e/go.mod h1:LZs0Ai6k5IPICeMqXRDpr1uyW7NJnoXgyrlaQh36XSM=
+github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250416145457-bc718b64c214 h1:CMXBcRQDqH73GvRjbfQC9h2Kc/eV92L0aHq6h5cdPuk=
+github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250416145457-bc718b64c214/go.mod h1:LZs0Ai6k5IPICeMqXRDpr1uyW7NJnoXgyrlaQh36XSM=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.20.0 h1:fKv05WFWHCXQmUTehW1eEZvXJP65Qv00W4V01B1EqSA=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.20.0/go.mod h1:dvIWN9pA2zWNTw5rhDWZgzZnhcfpH++d+8d1SWW6xkY=
 github.com/DataDog/sketches-go v1.4.5 h1:ki7VfeNz7IcNafq7yI/j5U/YCkO3LJiMDtXz9OMQbyE=

--- a/reporter/symbol_query_batching.go
+++ b/reporter/symbol_query_batching.go
@@ -69,20 +69,6 @@ func (e *ElfWithBackendSources) fillWithError(err error) {
 	}
 }
 
-func getBuildID(e *symbol.Elf) string {
-	// Only consider the first non-empty buildID between gnuBuildID, goBuildID and fileHash
-	// This simplifies the logic and profile will contain only this buildID anyway.
-	buildID := e.GnuBuildID()
-	if buildID != "" {
-		return buildID
-	}
-	buildID = e.GoBuildID()
-	if buildID != "" {
-		return buildID
-	}
-	return e.FileHash()
-}
-
 func ExecuteSymbolQueryBatch(ctx context.Context, batch SymbolQueryBatch, queriers []SymbolQuerier) []ElfWithBackendSources {
 	if len(batch) == 0 {
 		return nil
@@ -106,7 +92,7 @@ func ExecuteSymbolQueryBatch(ctx context.Context, batch SymbolQueryBatch, querie
 			continue
 		}
 
-		buildID := getBuildID(e)
+		buildID := getBuildID(e.GnuBuildID(), e.GoBuildID(), e.FileHash())
 		if buildID == "" {
 			result.fillWithError(errors.New("empty buildID"))
 			continue


### PR DESCRIPTION
# What does this PR do?

Centralize build id detection logic for both profiles and symbol querying in the datadog reporter

# Motivation

Fix symbolication for Bazel-built Go binaries using Go1.24+

# Additional Notes

N/A

# How to test the change?

N/A
