### PR TITLE
chore: bump Go version to 1.24.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,17 +24,18 @@ jobs:
     steps:
     - name: Check out
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Set up Go ${{ inputs.go-version }}
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+      with:
+        go-version: ${{ inputs.go-version }}
+        check-latest: true
     - name: Get linter version
       id: linter-version
       run: (echo -n "version="; make linter-version) >> "$GITHUB_OUTPUT"
-    - name: golangci-lint
-      uses: reviewdog/action-golangci-lint@f9bba13753278f6a73b27a56a3ffb1bfda90ed71 # v2.8.0
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
       with:
-        go_version: ${{ inputs.go-version }}
-        golangci_lint_version: ${{ steps.linter-version.outputs.version }}
-        fail_level: any
-        filter_mode: nofilter
-        reporter: github-pr-review
+        version: ${{ steps.linter-version.outputs.version }}
     - name: Verify copyright headers
       run: |
         go run tools/checkcopyright.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
-run:
-  timeout: 10m
-  
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
     # Disabled because of
     #   - too many non-sensical warnings
@@ -17,16 +15,13 @@ linters:
     - exhaustruct
     - forbidigo
     - funlen
-    - gci
     - gochecknoglobals
     - gochecknoinits
     - gocognit
     - goconst
     - gocyclo
     - godot
-    - godox # complains about TODO etc
-    - gofumpt
-    - gomnd
+    - godox
     - gomoddirectives
     - inamedparam
     - interfacebloat
@@ -47,47 +42,66 @@ linters:
     - thelper
     - varnamelen
     - wastedassign
-    - wsl
     - wrapcheck
-    # the following linters are deprecated
-    - execinquery
-    - exportloopref
-
-linters-settings:
-  goimports:
-    local-prefixes: github.com/DataDog/dd-otel-host-profiler
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - whyNoLint
-  gocyclo:
-    min-complexity: 15
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-    settings:
-      printf: # analyzer name, run `go tool vet help` to see all analyzers
-        funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
-          - debug,debugf,debugln
-          - error,errorf,errorln
-          - fatal,fatalf,fataln
-          - info,infof,infoln
-          - log,logf,logln
-          - warn,warnf,warnln
-          - print,printf,println,sprint,sprintf,sprintln,fprint,fprintf,fprintln
-  misspell:
-    locale: US
-    ignore-words:
-      - rela
-  gosec:
-    excludes:
-      - G115 # integer overflow, too many false positives
+    - wsl
+  settings:
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - whyNoLint
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 15
+    gosec:
+      excludes:
+        - G115 # integer overflow, too many false positives
+    govet:
+      disable:
+        - fieldalignment
+      enable-all: true
+      settings:
+        printf: # analyzer name, run `go tool vet help` to see all analyzers
+          funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
+            - debug,debugf,debugln
+            - error,errorf,errorln
+            - fatal,fatalf,fataln
+            - info,infof,infoln
+            - log,logf,logln
+            - warn,warnf,warnln
+            - print,printf,println,sprint,sprintf,sprintln,fprint,fprintf,fprintln
+    misspell:
+      locale: US
+      ignore-rules:
+        - rela
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/DataDog/dd-otel-host-profiler
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.6-bookworm@sha256:441f59f8a2104b99320e1f5aaf59a81baabbc36c81f4e792d5715ef09dd29355
+FROM golang:1.24.2-bookworm@sha256:79390b5e5af9ee6e7b1173ee3eac7fadf6751a545297672916b59bfa0ecf6f71
 
 RUN apt-get update -y && apt-get upgrade -y && apt-get install -y sudo && apt-get clean autoclean && apt-get autoremove --yes 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ RUN adduser build sudo
 
 USER build
 
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
 
 VOLUME /go

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,12 @@ all: build
 build:
 	go build $(GO_FLAGS)
 
-GOLANGCI_LINT_VERSION = "v1.61.0"
+GOLANGCI_LINT_VERSION = "v2.1.6"
 GO = $(shell go env GOROOT)/bin/go
 
 lint:
-	$(GO) run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) version
-	$(GO) run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run
+	$(GO) run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) version
+	$(GO) run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run
 
 linter-version:
 	@echo $(GOLANGCI_LINT_VERSION)

--- a/containermetadata/container.go
+++ b/containermetadata/container.go
@@ -119,9 +119,10 @@ func parseCgroupNodePath(r io.Reader) (cgroupV1BaseControllerPath, emptyControll
 		if len(tokens) != 3 {
 			continue
 		}
-		if tokens[1] == cgroupV1BaseController {
+		switch tokens[1] {
+		case cgroupV1BaseController:
 			cgroupV1BaseControllerPath = tokens[2]
-		} else if tokens[1] == "" {
+		case "":
 			emptyControllerPath = tokens[2]
 		}
 	}

--- a/containermetadata/containermetadata_test.go
+++ b/containermetadata/containermetadata_test.go
@@ -9,7 +9,6 @@
 package containermetadata
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -324,7 +323,7 @@ func TestGetKubernetesPodMetadata(t *testing.T) {
 }
 
 func BenchmarkGetKubernetesPodMetadata(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		clientset := fake.NewSimpleClientset()
 		containerMetadataCache, err := lru.NewSynced[string, ContainerMetadata](
 			containerMetadataCacheSize, hashString)
@@ -372,7 +371,7 @@ func BenchmarkGetKubernetesPodMetadata(b *testing.B) {
 				},
 			}
 
-			file, err := os.CreateTemp("", "test_containermetadata_cgroup*")
+			file, err := os.CreateTemp(b.TempDir(), "test_containermetadata_cgroup*")
 			require.NoError(b, err)
 			defer os.Remove(file.Name()) //nolint: gocritic
 
@@ -383,7 +382,7 @@ func BenchmarkGetKubernetesPodMetadata(b *testing.B) {
 
 			opts := v1.CreateOptions{}
 			clientsetPod, err := clientset.CoreV1().Pods("default").Create(
-				context.Background(), pod, opts)
+				b.Context(), pod, opts)
 			require.NoError(b, err)
 			instance.putCache(clientsetPod)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/dd-otel-host-profiler
 
-go 1.23.6
+go 1.24.2
 
 require (
 	github.com/DataDog/jsonapi v0.12.0

--- a/pclntab/pclntab_test.go
+++ b/pclntab/pclntab_test.go
@@ -40,7 +40,7 @@ func TestGoPCLnTabExtraction(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
-	goMinorVersions := []int{3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}
+	goMinorVersions := []int{3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}
 	for _, goMinorVersion := range goMinorVersions {
 		for name, test := range tests {
 			if goMinorVersion <= 12 && strings.HasPrefix(name, "pie") {

--- a/reporter/pipeline/pipeline_test.go
+++ b/reporter/pipeline/pipeline_test.go
@@ -19,7 +19,7 @@ func TestPipeline(t *testing.T) {
 	t.Run("EmptyPipeline", func(_ *testing.T) {
 		input := make(chan int)
 		p := NewPipeline(input)
-		p.Start(context.Background())
+		p.Start(t.Context())
 		p.Stop()
 	})
 
@@ -30,7 +30,7 @@ func TestPipeline(t *testing.T) {
 			func(_ context.Context, x int) {
 				output <- x * 2
 			}))
-		p.Start(context.Background())
+		p.Start(t.Context())
 		input <- 1
 		require.Equal(t, 2, <-output)
 		p.Stop()
@@ -52,7 +52,7 @@ func TestPipeline(t *testing.T) {
 				output <- sum
 			})
 		p := NewPipeline(input, stage1, stage2)
-		p.Start(context.Background())
+		p.Start(t.Context())
 		go func() {
 			input <- 1
 			input <- 2
@@ -85,7 +85,7 @@ func TestPipeline(t *testing.T) {
 			}, WithConcurrency(10))
 
 		p := NewPipeline(input, stage1, stage2, stage3)
-		p.Start(context.Background())
+		p.Start(t.Context())
 		p.Stop()
 		require.Len(t, output, 1000)
 	})
@@ -102,7 +102,7 @@ func TestPipeline(t *testing.T) {
 				output = append(output, x)
 			})
 		p := NewPipeline(input, stage1, stage2)
-		p.Start(context.Background())
+		p.Start(t.Context())
 		p.Stop()
 		require.Len(t, output, 100)
 		require.Len(t, output[99], 9)
@@ -115,7 +115,7 @@ func TestPipeline(t *testing.T) {
 			WithOutputChanSize(1))
 		p := NewPipeline(input, stage1)
 		output := stage1.GetOutputChannel()
-		p.Start(context.Background())
+		p.Start(t.Context())
 		for i := range 9 {
 			input <- i
 		}

--- a/reporter/symbol/elf_wrapper.go
+++ b/reporter/symbol/elf_wrapper.go
@@ -39,10 +39,6 @@ func (e *elfWrapper) Close() {
 	_ = e.reader.Close()
 }
 
-func (e *elfWrapper) openELF(filePath string) (*elfWrapper, error) {
-	return openELF(filePath, e.opener)
-}
-
 func openELF(filePath string, opener process.FileOpener) (*elfWrapper, error) {
 	r, actualFilePath, err := opener.Open(filePath)
 	if err != nil {
@@ -64,6 +60,89 @@ func openELF(filePath string, opener process.FileOpener) (*elfWrapper, error) {
 		return nil, err
 	}
 	return &elfWrapper{reader: r, elfFile: ef, filePath: filePath, actualFilePath: actualFilePath, opener: opener}, nil
+}
+
+func (e *elfWrapper) DumpDynamicSymbols() (*DynamicSymbolsDump, error) {
+	dynSymFile, err := os.CreateTemp("", "dynsym")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp file to extract dynamic symbols: %w", err)
+	}
+	defer func() {
+		dynSymFile.Close()
+		if err != nil {
+			os.Remove(dynSymFile.Name())
+		}
+	}()
+
+	dynStrFile, err := os.CreateTemp("", "dynstr")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp file to extract dynamic symbols: %w", err)
+	}
+	defer func() {
+		dynStrFile.Close()
+		if err != nil {
+			os.Remove(dynStrFile.Name())
+		}
+	}()
+
+	dynSymSection := e.elfFile.Section(".dynsym")
+	if dynSymFile == nil {
+		return nil, errors.New("failed to find .dynsym section")
+	}
+	data, err := dynSymSection.Data(maxBytesLargeSection)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read .dynsym section: %w", err)
+	}
+	_, err = dynSymFile.Write(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write .dynsym section: %w", err)
+	}
+
+	dynStrSection := e.elfFile.Section(".dynstr")
+	if dynStrFile == nil {
+		return nil, errors.New("failed to find .dynstr section")
+	}
+	data, err = dynStrSection.Data(maxBytesLargeSection)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read .dynstr section: %w", err)
+	}
+	_, err = dynStrFile.Write(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write .dynstr section: %w", err)
+	}
+
+	return &DynamicSymbolsDump{
+		DynSymPath:  dynSymFile.Name(),
+		DynStrPath:  dynStrFile.Name(),
+		DynSymAddr:  dynSymSection.Addr,
+		DynStrAddr:  dynStrSection.Addr,
+		DynSymAlign: dynSymSection.Addralign,
+		DynStrAlign: dynStrSection.Addralign,
+	}, nil
+}
+
+func (e *elfWrapper) DumpElfData() (string, error) {
+	tempElfFile, err := os.CreateTemp("", "elf")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file to dump elf data: %w", err)
+	}
+
+	defer func() {
+		tempElfFile.Close()
+		if err != nil {
+			os.Remove(tempElfFile.Name())
+		}
+	}()
+
+	_, err = io.Copy(tempElfFile, io.NewSectionReader(e.reader, 0, 1<<63-1))
+	if err != nil {
+		return "", fmt.Errorf("failed to dump elf data: %w", err)
+	}
+	return tempElfFile.Name(), nil
+}
+
+func (e *elfWrapper) openELF(filePath string) (*elfWrapper, error) {
+	return openELF(filePath, e.opener)
 }
 
 func (e *elfWrapper) symbolSource() Source {
@@ -176,85 +255,6 @@ func (e *elfWrapper) findDebugSymbolsWithDebugLink() *elfWrapper {
 		return debugELF
 	}
 	return nil
-}
-
-func (e *elfWrapper) DumpDynamicSymbols() (*DynamicSymbolsDump, error) {
-	dynSymFile, err := os.CreateTemp("", "dynsym")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp file to extract dynamic symbols: %w", err)
-	}
-	defer func() {
-		dynSymFile.Close()
-		if err != nil {
-			os.Remove(dynSymFile.Name())
-		}
-	}()
-
-	dynStrFile, err := os.CreateTemp("", "dynstr")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp file to extract dynamic symbols: %w", err)
-	}
-	defer func() {
-		dynStrFile.Close()
-		if err != nil {
-			os.Remove(dynStrFile.Name())
-		}
-	}()
-
-	dynSymSection := e.elfFile.Section(".dynsym")
-	if dynSymFile == nil {
-		return nil, errors.New("failed to find .dynsym section")
-	}
-	data, err := dynSymSection.Data(maxBytesLargeSection)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read .dynsym section: %w", err)
-	}
-	_, err = dynSymFile.Write(data)
-	if err != nil {
-		return nil, fmt.Errorf("failed to write .dynsym section: %w", err)
-	}
-
-	dynStrSection := e.elfFile.Section(".dynstr")
-	if dynStrFile == nil {
-		return nil, errors.New("failed to find .dynstr section")
-	}
-	data, err = dynStrSection.Data(maxBytesLargeSection)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read .dynstr section: %w", err)
-	}
-	_, err = dynStrFile.Write(data)
-	if err != nil {
-		return nil, fmt.Errorf("failed to write .dynstr section: %w", err)
-	}
-
-	return &DynamicSymbolsDump{
-		DynSymPath:  dynSymFile.Name(),
-		DynStrPath:  dynStrFile.Name(),
-		DynSymAddr:  dynSymSection.Addr,
-		DynStrAddr:  dynStrSection.Addr,
-		DynSymAlign: dynSymSection.Addralign,
-		DynStrAlign: dynStrSection.Addralign,
-	}, nil
-}
-
-func (e *elfWrapper) DumpElfData() (string, error) {
-	tempElfFile, err := os.CreateTemp("", "elf")
-	if err != nil {
-		return "", fmt.Errorf("failed to create temp file to dump elf data: %w", err)
-	}
-
-	defer func() {
-		tempElfFile.Close()
-		if err != nil {
-			os.Remove(tempElfFile.Name())
-		}
-	}()
-
-	_, err = io.Copy(tempElfFile, io.NewSectionReader(e.reader, 0, 1<<63-1))
-	if err != nil {
-		return "", fmt.Errorf("failed to dump elf data: %w", err)
-	}
-	return tempElfFile.Name(), nil
 }
 
 // HasDWARFData is a copy of pfelf.HasDWARFData, but for the libpf.File interface.

--- a/reporter/symbol/source.go
+++ b/reporter/symbol/source.go
@@ -17,6 +17,22 @@ const (
 	SourceDebugInfo
 )
 
+func NewSource(s string) (Source, error) {
+	switch s {
+	case "none":
+		return SourceNone, nil
+	case "dynamic_symbol_table":
+		return SourceDynamicSymbolTable, nil
+	case "symbol_table":
+		return SourceSymbolTable, nil
+	case "debug_info":
+		return SourceDebugInfo, nil
+	case "gopclntab":
+		return SourceGoPCLnTab, nil
+	}
+	return SourceNone, fmt.Errorf("unknown symbol source: %s", s)
+}
+
 func (s Source) String() string {
 	switch s {
 	case SourceNone:
@@ -32,20 +48,4 @@ func (s Source) String() string {
 	}
 
 	return "unknown"
-}
-
-func NewSource(s string) (Source, error) {
-	switch s {
-	case "none":
-		return SourceNone, nil
-	case "dynamic_symbol_table":
-		return SourceDynamicSymbolTable, nil
-	case "symbol_table":
-		return SourceSymbolTable, nil
-	case "debug_info":
-		return SourceDebugInfo, nil
-	case "gopclntab":
-		return SourceGoPCLnTab, nil
-	}
-	return SourceNone, fmt.Errorf("unknown symbol source: %s", s)
 }

--- a/reporter/symbol_query_batching_test.go
+++ b/reporter/symbol_query_batching_test.go
@@ -98,7 +98,7 @@ func TestBatchSymbolQuerier_Multiplexing(t *testing.T) {
 
 	queriers := []SymbolQuerier{querier1, querier2}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	t.Run("Empty batch", func(t *testing.T) {

--- a/reporter/symbol_uploader_test.go
+++ b/reporter/symbol_uploader_test.go
@@ -6,7 +6,6 @@
 package reporter
 
 import (
-	"context"
 	"debug/elf"
 	"encoding/json"
 	"io"
@@ -96,7 +95,7 @@ func checkGoPCLnTabExtraction(t *testing.T, filename, tmpDir string) {
 	assert.NotNil(t, goPCLnTabInfo)
 
 	outputFile := filepath.Join(tmpDir, "output.dbg")
-	err = CopySymbols(context.Background(), filename, outputFile, goPCLnTabInfo, nil, false)
+	err = CopySymbols(t.Context(), filename, outputFile, goPCLnTabInfo, nil, false)
 	require.NoError(t, err)
 	f, err := elf.Open(outputFile)
 	require.NoError(t, err)
@@ -350,7 +349,7 @@ func TestSymbolUpload(t *testing.T) {
 		httpmock.ZeroCallCounters()
 		uploader, err := newTestUploader(uploaderOpts{})
 		require.NoError(t, err)
-		uploader.Start(context.Background())
+		uploader.Start(t.Context())
 
 		uploader.UploadSymbols(libpf.FileID{}, goExeNoSymbols, buildID, &symbol.DiskOpener{})
 		uploader.Stop()
@@ -362,7 +361,7 @@ func TestSymbolUpload(t *testing.T) {
 		httpmock.ZeroCallCounters()
 		uploader, err := newTestUploader(uploaderOpts{})
 		require.NoError(t, err)
-		uploader.Start(context.Background())
+		uploader.Start(t.Context())
 
 		uploader.UploadSymbols(libpf.FileID{}, goExeSymtab, "build_id", &symbol.DiskOpener{})
 		uploader.Stop()
@@ -374,7 +373,7 @@ func TestSymbolUpload(t *testing.T) {
 		httpmock.ZeroCallCounters()
 		uploader, err := newTestUploader(uploaderOpts{})
 		require.NoError(t, err)
-		uploader.Start(context.Background())
+		uploader.Start(t.Context())
 
 		uploader.UploadSymbols(libpf.FileID{}, goExeDebugInfos, "build_id", &symbol.DiskOpener{})
 		uploader.Stop()
@@ -386,7 +385,7 @@ func TestSymbolUpload(t *testing.T) {
 		httpmock.ZeroCallCounters()
 		uploader, err := newTestUploader(uploaderOpts{})
 		require.NoError(t, err)
-		uploader.Start(context.Background())
+		uploader.Start(t.Context())
 
 		uploader.UploadSymbols(libpf.FileID{}, goExeyDynsym, "build_id", &symbol.DiskOpener{})
 		uploader.Stop()
@@ -398,7 +397,7 @@ func TestSymbolUpload(t *testing.T) {
 		httpmock.ZeroCallCounters()
 		uploader, err := newTestUploader(uploaderOpts{uploadDynamicSymbols: true})
 		require.NoError(t, err)
-		uploader.Start(context.Background())
+		uploader.Start(t.Context())
 
 		uploader.UploadSymbols(libpf.FileID{}, goExeyDynsym, "build_id", &symbol.DiskOpener{})
 		uploader.Stop()
@@ -410,7 +409,7 @@ func TestSymbolUpload(t *testing.T) {
 		httpmock.ZeroCallCounters()
 		uploader, err := newTestUploader(uploaderOpts{uploadGoPCLnTab: true})
 		require.NoError(t, err)
-		uploader.Start(context.Background())
+		uploader.Start(t.Context())
 
 		uploader.UploadSymbols(libpf.FileID{}, goExeNoSymbols, "build_id", &symbol.DiskOpener{})
 		uploader.Stop()
@@ -422,7 +421,7 @@ func TestSymbolUpload(t *testing.T) {
 		httpmock.ZeroCallCounters()
 		uploader, err := newTestUploader(uploaderOpts{uploadGoPCLnTab: true})
 		require.NoError(t, err)
-		uploader.Start(context.Background())
+		uploader.Start(t.Context())
 
 		uploader.UploadSymbols(libpf.FileID{}, goExeDebugInfosCorruptGoPCLnTab, "build_id", &symbol.DiskOpener{})
 		uploader.Stop()
@@ -434,7 +433,7 @@ func TestSymbolUpload(t *testing.T) {
 		httpmock.ZeroCallCounters()
 		uploader, err := newTestUploader(uploaderOpts{uploadDynamicSymbols: true, uploadGoPCLnTab: true})
 		require.NoError(t, err)
-		uploader.Start(context.Background())
+		uploader.Start(t.Context())
 
 		uploader.UploadSymbols(libpf.FileID{}, goExeyDynsymCorruptGoPCLnTab, "build_id", &symbol.DiskOpener{})
 		uploader.Stop()
@@ -446,7 +445,7 @@ func TestSymbolUpload(t *testing.T) {
 		httpmock.ZeroCallCounters()
 		uploader, err := newTestUploader(uploaderOpts{uploadGoPCLnTab: true})
 		require.NoError(t, err)
-		uploader.Start(context.Background())
+		uploader.Start(t.Context())
 
 		uploader.UploadSymbols(libpf.FileID{}, goExeyDynsymCorruptGoPCLnTab, "build_id", &symbol.DiskOpener{})
 		uploader.Stop()
@@ -458,7 +457,7 @@ func TestSymbolUpload(t *testing.T) {
 		httpmock.ZeroCallCounters()
 		uploader, err := newTestUploader(uploaderOpts{disableDebugSectionCompression: true})
 		require.NoError(t, err)
-		uploader.Start(context.Background())
+		uploader.Start(t.Context())
 
 		uploader.UploadSymbols(libpf.FileID{}, goExeDebugInfos, "build_id", &symbol.DiskOpener{})
 		uploader.Stop()


### PR DESCRIPTION
# Motivation

* Bump Go version to 1.24.2 to fix [GO-2025-3563](https://github.com/DataDog/dd-otel-host-profiler/actions/runs/14836064238/job/41647509934)
* Bump golangci version and use https://github.com/golangci/golangci-lint-action instead of https://github.com/reviewdog/action-golangci-lint
