### PR TITLE
fix: improve DD_SERVICE detection for containerized processes

### DIFF
--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -829,6 +829,7 @@ func (r *DatadogReporter) getDDService(pid libpf.PID) string {
 	envPath, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
 	if err != nil {
 		log.Debugf("Failed to read environ for PID %d: %v", pid, err)
+		return ""
 	}
 
 	for _, envVar := range bytes.Split(envPath, []byte{0}) {

--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -698,9 +698,11 @@ func createTagsForProfile(tags Tags, profileSeq uint64, service string, inferred
 	newTags = append(newTags,
 		MakeTag("profile_seq", strconv.FormatUint(profileSeq, 10)),
 		MakeTag("service", service))
+	inferredServiceTag := "no"
 	if inferredService {
-		newTags = append(newTags, MakeTag("service_inferred", "yes"))
+		inferredServiceTag = "yes"
 	}
+	newTags = append(newTags, MakeTag("service_inferred", inferredServiceTag))
 	return newTags
 }
 


### PR DESCRIPTION
# What does this PR do?

When a container starts, the initial process is runc which then execs into the final binary with the container environment.
This change improves DD_SERVICE detection by:

* First checking if DD_SERVICE is set in the trace metadata
* If not set and executable path differs from trace path (indicating exec), reading DD_SERVICE from process environment# 

# Additional Notes

Also emit `service_inferred:no` tag even when service is not inferred.