### PR TITLE
fix: Improve dynamic symbol extraction

### DIFF
--- a/reporter/symbol/elf.go
+++ b/reporter/symbol/elf.go
@@ -40,17 +40,7 @@ type Elf struct {
 	goPCLnTabInfo    *pclntab.GoPCLnTabInfo
 	goPCLnTabInfoErr error
 
-	dynamicSymbolsDump *DynamicSymbolsDump
-	elfDataDump        string
-}
-
-type DynamicSymbolsDump struct {
-	DynSymPath  string
-	DynStrPath  string
-	DynSymAddr  uint64
-	DynStrAddr  uint64
-	DynSymAlign uint64
-	DynStrAlign uint64
+	elfDataDump string
 }
 
 func NewElf(path string, fileID libpf.FileID, opener process.FileOpener) (*Elf, error) {
@@ -157,9 +147,6 @@ func (e *Elf) Close() {
 	if e.separateSymbols != nil {
 		e.separateSymbols.wrapper.Close()
 	}
-	if e.dynamicSymbolsDump != nil {
-		e.dynamicSymbolsDump.Remove()
-	}
 	if e.elfDataDump != "" {
 		os.Remove(e.elfDataDump)
 	}
@@ -217,16 +204,8 @@ func (e *Elf) DumpElfData() (string, error) {
 	return elfDataDump, nil
 }
 
-func (e *Elf) DumpDynamicSymbols() (*DynamicSymbolsDump, error) {
-	if e.dynamicSymbolsDump != nil {
-		return e.dynamicSymbolsDump, nil
-	}
-	dynamicSymbolsDump, err := e.wrapper.DumpDynamicSymbols()
-	if err != nil {
-		return nil, err
-	}
-	e.dynamicSymbolsDump = dynamicSymbolsDump
-	return dynamicSymbolsDump, nil
+func (e *Elf) GetSectionsRequiredForDynamicSymbols() []SectionInfo {
+	return e.wrapper.GetSectionsRequiredForDynamicSymbols()
 }
 
 func (e *Elf) goPCLnTab() (*pclntab.GoPCLnTabInfo, error) {
@@ -240,11 +219,6 @@ func (e *Elf) goPCLnTab() (*pclntab.GoPCLnTabInfo, error) {
 	}
 
 	return goPCLnTab, nil
-}
-
-func (d *DynamicSymbolsDump) Remove() {
-	os.Remove(d.DynSymPath)
-	os.Remove(d.DynStrPath)
 }
 
 type DiskOpener struct{}

--- a/tools/extract_symbols/main.go
+++ b/tools/extract_symbols/main.go
@@ -29,15 +29,12 @@ func extractDebugInfos(elfFile, outFile string) error {
 		fmt.Printf("Found GoFunc at 0x%x, size %d\n", goPCLnTabInfo.GoFuncAddr, len(goPCLnTabInfo.GoFuncData))
 	}
 
-	var dynamicSymbolsDump *symbol.DynamicSymbolsDump
+	var sectionsToKeep []symbol.SectionInfo
 	if ef.SymbolSource() == symbol.SourceDynamicSymbolTable {
-		dynamicSymbolsDump, err = ef.DumpDynamicSymbols()
-		if err != nil {
-			return fmt.Errorf("failed to dump dynamic symbols: %w", err)
-		}
+		sectionsToKeep = ef.GetSectionsRequiredForDynamicSymbols()
 	}
 
-	return reporter.CopySymbols(context.Background(), elfFile, outFile, goPCLnTabInfo, dynamicSymbolsDump, reporter.CheckObjcopyZstdSupport())
+	return reporter.CopySymbols(context.Background(), elfFile, outFile, goPCLnTabInfo, sectionsToKeep, reporter.CheckObjcopyZstdSupport())
 }
 
 func main() {


### PR DESCRIPTION
# What does this PR do?

* Simplify dynamic symbol extraction by using `--set-section-flags` instead of dumping the dynamic sections to a file, removing the sections and adding them back. `--set-section-flags` with `content` flag seems to prevent `--only-keep-debug` from removing the section contents (setting their size to 0). It also ensures that section indices are preserved.
* Keep additional sections required by symbolic for dynamic symbols (`.gnu.hash`, `.gnu.version*`, `.rel*`).

# Motivation

Make dynamic symbols work with the current version of symbolic.
