### PR TITLE
feat: enable symbol upload and split by service by default

### DIFF
--- a/cli_flags.go
+++ b/cli_flags.go
@@ -293,7 +293,7 @@ func parseArgs() (*arguments, error) {
 			},
 			&cli.BoolFlag{
 				Name:        "upload-symbols",
-				Value:       false,
+				Value:       true,
 				Usage:       "Enable local symbol upload.",
 				Hidden:      true,
 				Destination: &args.uploadSymbols,
@@ -310,7 +310,7 @@ func parseArgs() (*arguments, error) {
 			&cli.BoolFlag{
 				Name:        "upload-gopclntab",
 				Usage:       "Enable gopcnltab upload.",
-				Value:       false,
+				Value:       true,
 				Hidden:      true,
 				Sources:     cli.EnvVars("DD_HOST_PROFILING_EXPERIMENTAL_UPLOAD_GOPCLNTAB"),
 				Destination: &args.uploadGoPCLnTab,
@@ -381,7 +381,7 @@ func parseArgs() (*arguments, error) {
 			},
 			&cli.BoolFlag{
 				Name:        "split-by-service",
-				Value:       false,
+				Value:       true,
 				Usage:       "Split profiles by service.",
 				Destination: &args.enableSplitByService,
 				Sources:     cli.EnvVars("DD_HOST_PROFILING_SPLIT_BY_SERVICE"),

--- a/doc/running-in-docker.md
+++ b/doc/running-in-docker.md
@@ -28,7 +28,6 @@ docker run \
   --privileged \
   --cap-add=SYS_ADMIN \
   -e DD_TRACE_AGENT_URL=http://<agent_address>:8126 \
-  -e DD_HOST_PROFILING_SERVICE="$(hostname)" \
   -e DD_SERVICE="dd-otel-host-profiler" \
   -v /var/run/docker.sock:/var/run/docker.sock \
   ghcr.io/datadog/dd-otel-host-profiler:latest

--- a/doc/running-in-kubernetes.md
+++ b/doc/running-in-kubernetes.md
@@ -53,8 +53,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: DD_HOST_PROFILING_SERVICE
-          value: "$(KUBERNETES_NODE_NAME)" # will inherit the variable set above
         - name: DD_SERVICE
           value: "dd-otel-host-profiler"
         # ...

--- a/doc/running-on-host.md
+++ b/doc/running-on-host.md
@@ -37,7 +37,7 @@ sudo mount -t debugfs none /sys/kernel/debug
 After that, you can start the profiler as shown below (make sure you run it as root):
 
 ```
-sudo DD_SERVICE="dd-otel-host-profiler" dd-otel-host-profiler --host-service "$(hostname)" --agent-url "http://localhost:8126"
+sudo DD_SERVICE="dd-otel-host-profiler" dd-otel-host-profiler --agent-url "http://localhost:8126"
 ```
 
 If your Datadog agent is reachable under a different address, you can modify the `--agent-url` parameter accordingly.


### PR DESCRIPTION
# What does this PR do?

Enable symbol upload and split by service by default.
