### PR TITLE
chore: update go to 1.24.4

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.2-bookworm@sha256:79390b5e5af9ee6e7b1173ee3eac7fadf6751a545297672916b59bfa0ecf6f71
+FROM golang:1.24.4-bookworm@sha256:ee7ff13d239350cc9b962c1bf371a60f3c32ee00eaaf0d0f0489713a87e51a67
 
 RUN apt-get update -y && apt-get upgrade -y && apt-get install -y sudo make && apt-get clean autoclean && apt-get autoremove --yes
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/dd-otel-host-profiler
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/DataDog/jsonapi v0.12.0


### PR DESCRIPTION
# What does this PR do?

Update Go to 1.24.4 to fix [govulncheck failure](https://github.com/DataDog/dd-otel-host-profiler/actions/runs/15973164006/job/45048825870).
