### PR TITLE
reporter: system is not an inferred service

### DIFF
--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -628,7 +628,6 @@ func (r *DatadogReporter) getPprofProfile() {
 		if service == "" && len(traceInfo.frameTypes) > 0 &&
 			traceInfo.frameTypes[len(traceInfo.frameTypes)-1] == libpf.KernelFrame {
 			service = "system"
-			inferredService = true
 		}
 
 		if service == "" {


### PR DESCRIPTION
# What does this PR do?

Stop marking system as an inferred service.

# Motivation

system represents threads that are launched by the kernel, there is no way to set a DD_SERVICE environment variable for these threads, as such we should not mark them as inferred (which would cause the tooltip that suggests to set DD_SERVICE to appear).

# Additional Notes

The tooltip we'd like to avoid showing:
<img width="395" alt="image" src="https://github.com/user-attachments/assets/176f1fb0-a949-496d-9fe4-c70d04d0bc55" />

# How to test the change?

N/A
