### PR TITLE
[PROF-12186] Bump opentelemetry-ebpf-profiler to include nsolid fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -128,4 +128,4 @@ require (
 // To update the Datadog/opentelemetry-ebpf-profiler dependency on latest commit on datadog branch, change the following line to:
 // replace go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler datadog
 // and run `go mod tidy`
-replace go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250427124427-bdecaafa3d27
+replace go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250728155009-e8783b5032af

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/
 github.com/DataDog/gostackparse v0.7.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/DataDog/jsonapi v0.12.0 h1:N4e9RpmUflcV5hzceltSz8XUpM3PMtQr5C9Bhv0g87s=
 github.com/DataDog/jsonapi v0.12.0/go.mod h1:FUSGF3bwMARlVfXEoFo9R/CVlYYy9BGL4C/Prf6Ke3M=
-github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250427124427-bdecaafa3d27 h1:LHa2gryn5n3M1BTTnGg+K0KBsQPscPjQOr2+PN2sdqI=
-github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250427124427-bdecaafa3d27/go.mod h1:zYNmE98qCkBe1U3RT8RakZE9zODxCDj6fc/rCaaCqK4=
+github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250728155009-e8783b5032af h1:BqRbIR0zfwMovN6pFVsHlh9nHnbCkA8qJVWf5rdiVhE=
+github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20250728155009-e8783b5032af/go.mod h1:zYNmE98qCkBe1U3RT8RakZE9zODxCDj6fc/rCaaCqK4=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.20.0 h1:fKv05WFWHCXQmUTehW1eEZvXJP65Qv00W4V01B1EqSA=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.20.0/go.mod h1:dvIWN9pA2zWNTw5rhDWZgzZnhcfpH++d+8d1SWW6xkY=
 github.com/DataDog/sketches-go v1.4.5 h1:ki7VfeNz7IcNafq7yI/j5U/YCkO3LJiMDtXz9OMQbyE=


### PR DESCRIPTION
# What does this PR do?

- Generated the version by following https://github.com/DataDog/dd-otel-host-profiler/blob/e9bead8260239cb5090d5f1d0835fbc96af6e6fe/go.mod#L128
- Bump our fork of opentelemetry-ebpf-profiler to include these changes (https://github.com/DataDog/opentelemetry-ebpf-profiler/pull/20)

# Motivation

Address https://github.com/DataDog/dd-otel-host-profiler/issues/168

# Additional Notes

N/A

# How to test the change?

Tested on workspace environment, produced reasonable profiles and flamegraphs. Don't have a node.js / nsolid setup, but would test on that if we did. Should work identically to upstream though, and those changes are mostly a regex change so don't expect that it behave strangely.
