### PR TITLE
fix(symbol_uploader): reduce parallel uploads

### DIFF
--- a/reporter/symbol_uploader.go
+++ b/reporter/symbol_uploader.go
@@ -49,7 +49,7 @@ const (
 	defaultQueryWorkerCount     = 10
 
 	defaultUploadQueueSize   = 1000
-	defaultUploadWorkerCount = 10
+	defaultUploadWorkerCount = 5
 
 	sourceMapEndpoint = "/api/v2/srcmap"
 


### PR DESCRIPTION
# What does this PR do?

reduce parallel symbol uploads from 10 to 5.

# Motivation

reduce parallel uploads from 10 to 5. we've observed that a high number of parallel uploads can cause the profiler to get OOMKilled on startup, especially when uploading symbols is slow.

this should reduce the risk of getting OOMKills, while keeping sufficient paralellism for the uploads to be fast.

the number chosen (5) is slightly random: in a scenario where symbols can be in order of magnitude of ~100MiB in size, this allows us to cap memory usage to ~500MiB on startup.

# Additional Notes

N/A

# How to test the change?

Tests should still be green, this is not expected to have any side-effects beyond a small tweak in config.
