### PR TITLE
fix(symbol_upload): disable the use of HTTP/2 when uploading symbols

### DIFF
--- a/cli_flags.go
+++ b/cli_flags.go
@@ -102,6 +102,7 @@ type arguments struct {
 	environment                   string
 	uploadSymbolQueryInterval     time.Duration
 	uploadSymbols                 bool
+	uploadSymbolsHTTP2            bool
 	uploadDynamicSymbols          bool
 	uploadGoPCLnTab               bool
 	uploadSymbolsDryRun           bool
@@ -408,6 +409,14 @@ func parseArgs() (*arguments, error) {
 				Usage:       "Suffix to add to service name in profiles when split-by-service is enabled.",
 				Destination: &args.splitServiceSuffix,
 				Sources:     cli.EnvVars("DD_HOST_PROFILING_SPLIT_SERVICE_SUFFIX"),
+			},
+			&cli.BoolFlag{
+				Name:        "upload-symbols-http2",
+				Value:       false, // HTTP/2 is disabled by default, since support in the backend is recent
+				Hidden:      true,
+				Usage:       "Use HTTP/2 when available for symbol upload. Only used if upload-symbols is enabled.",
+				Destination: &args.uploadSymbolsHTTP2,
+				Sources:     cli.EnvVars("DD_HOST_PROFILING_UPLOAD_SYMBOLS_HTTP2"),
 			},
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {

--- a/main.go
+++ b/main.go
@@ -266,6 +266,7 @@ func mainWithExitCode() exitCode {
 			Enabled:              args.uploadSymbols,
 			UploadDynamicSymbols: args.uploadDynamicSymbols,
 			UploadGoPCLnTab:      args.uploadGoPCLnTab,
+			UseHTTP2:             args.uploadSymbolsHTTP2,
 			SymbolQueryInterval:  args.uploadSymbolQueryInterval,
 			DryRun:               args.uploadSymbolsDryRun,
 			SymbolEndpoints:      symbolEndpoints,

--- a/reporter/config.go
+++ b/reporter/config.go
@@ -63,6 +63,8 @@ type SymbolUploaderConfig struct {
 	UploadDynamicSymbols bool
 	// UploadGoPCLnTab defines whether the agent should upload GoPCLnTab section for Go binaries to the backend.
 	UploadGoPCLnTab bool
+	// UseHTTP2 defines whether the agent should use HTTP/2 when uploading symbols.
+	UseHTTP2 bool
 	// SymbolQueryInterval defines the interval at which the agent should query the backend for symbols. A value of 0 disables batching.
 	SymbolQueryInterval time.Duration
 	// DisableDebugSectionCompression defines whether the uploader should disable debug section compression whatever objcopy supports.


### PR DESCRIPTION
# What does this PR do?

Disable HTTP/2 upload by default (add support behind a config flag) per https://pkg.go.dev/net/http#hdr-HTTP_2

# Motivation

currently, we use HTTP/2 when available to upload symbols. however, the symbol intake backend has only started supporting HTTP/2 more recently, and we've observed significantly slower uploads when using HTTP/2 due to misconfigured window sizes on the server-side.

since most of the symbol upload traffic uses datadog-ci, which doesn't support HTTP/2 (due to the usage of axios), we decided to disable HTTP/2 on the client to align with datadog-ci, and the majority of the symbol intake traffic.

# Additional Notes

N/A

# How to test the change?

Tested locally, uploads continue to work:
```
full-host-profiler-1  | time="2025-08-12T13:54:48Z" level=info msg="Symbols uploaded successfully for executable: /app/dd-otel-host-profiler/dd-otel-host-profiler, arch=amd64, gnu_build_id=f476f51f12b6a4d26ed3537467ccbebe753d8269, go_build_id=SDXhjMFEJbJxU0AkvZwf/D3gyPxSljwbsGtg7WH5D/5o04m-U4VU7G_KAQxnkX/-dXu2JHj3XR9_gkwe64x, file_hash=a5c88db751d6112f47dbdb13fd640963, symbol_source=debug_info, has_gopclntab=true"
```
