### PR TITLE
bugfix: Do not look for .debug_frame in separate debug files

### DIFF
--- a/reporter/symbol/elf_wrapper.go
+++ b/reporter/symbol/elf_wrapper.go
@@ -217,10 +217,6 @@ func (e *elfWrapper) findDebugSymbolsWithDebugLink() *elfWrapper {
 		if err != nil {
 			continue
 		}
-		if debugELF.elfFile.Section(".debug_frame") == nil {
-			debugELF.Close()
-			continue
-		}
 		fileCRC32, err := debugELF.elfFile.CRC32()
 		if err != nil || fileCRC32 != linkCRC32 {
 			debugELF.Close()

--- a/reporter/symbol/elf_wrapper.go
+++ b/reporter/symbol/elf_wrapper.go
@@ -172,13 +172,8 @@ func (e *elfWrapper) findDebugSymbolsWithBuildID() *elfWrapper {
 	}
 
 	// Try to find the debug file
-	debugDirectories := make([]string, 0, len(globalDebugDirectories))
 	for _, dir := range globalDebugDirectories {
-		debugDirectories = append(debugDirectories, filepath.Join(dir, ".build-id"))
-	}
-
-	for _, debugPath := range debugDirectories {
-		debugFile := filepath.Join(debugPath, buildID[:2], buildID[2:]+".debug")
+		debugFile := filepath.Join(dir, ".build-id", buildID[:2], buildID[2:]+".debug")
 		debugELF, err := e.openELF(debugFile)
 		if err != nil {
 			continue


### PR DESCRIPTION
# What does this PR do?

`.debug_frame` section does not appear to be present in separate debug infos.