### PR TITLE
chore: don't tag release candidate containers as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,8 @@ jobs:
           annotations: |
             org.opencontainers.image.description=The Datadog OpenTelemetry Profiler is a full-host profiler that collects and sends profiling data to Datadog
             org.opencontainers.image.vendor=Datadog
+          flavor: |
+            latest=${{ contains(github.ref_name, '-rc') && 'false' || 'true' }}
       - name: Download artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
       - name: Create assets


### PR DESCRIPTION
# What does this PR do?

Don't tag release candidate containers as latest

# Motivation

currently, release candidate containers are tagged as latest since they are triggered from tags, see https://github.com/docker/metadata-action?tab=readme-ov-file#latest-tag

however, we don't want release candidates to be released as latest.

this commit fixes this by using the flavor input, see https://github.com/docker/metadata-action?tab=readme-ov-file#flavor-input

# Additional Notes

N/A

# How to test the change?

Will be tested for the newest 0.4.0 rc
