### PR TITLE
Revert kernel frames formatting

### DIFF
--- a/reporter/pprof/profile_builder.go
+++ b/reporter/pprof/profile_builder.go
@@ -90,15 +90,10 @@ func (b *ProfileBuilder) AddEvents(events samples.KeyToEventMapping) {
 				// that are not originate from a native or interpreted
 				// program.
 			default:
-				sourceFile := frame.SourceFile.String()
-				if frameKind == libpf.KernelFrame {
-					sourceFile = "kernel"
-				}
-
 				// Store interpreted frame information as Line message:
 				line := pprofile.Line{
 					Line:     int64(frame.SourceLine),
-					Function: b.createPprofFunctionEntry(frame.FunctionName.String(), sourceFile),
+					Function: b.createPprofFunctionEntry(frame.FunctionName.String(), frame.SourceFile.String()),
 				}
 
 				loc.Line = append(loc.Line, line)
@@ -118,11 +113,7 @@ func (b *ProfileBuilder) AddEvents(events samples.KeyToEventMapping) {
 
 		case samples.IsKernel(traceInfo.Frames):
 			execPath = "kernel"
-			if processMeta.ProcessName != "" {
-				baseExec = processMeta.ProcessName
-			} else {
-				baseExec = execPath
-			}
+			baseExec = execPath
 
 		default:
 			execPath = traceKey.Comm


### PR DESCRIPTION


# What does this PR do?

Revert recent changes to kernel frame formatting

# Motivation

The reasoning is that:
- The (kernel) next to each function name looks repetitive
- The file name is preventing the frames from being greyed out
- The frame logic is virtually separating system frames which can hurt readbility

In the longer term, we should have access to frame kind via https://opentelemetry.io/docs/specs/semconv/registry/attributes/profile/#profile-frame-attributes

This means we can properly differentiate kernel frames, and change UI behaviour based on a dedicated field.

# Additional Notes

N/A

# How to test the change?

Tested on a workspace:

<img width="319" height="235" alt="image" src="https://github.com/user-attachments/assets/57da9ebb-09c1-4ca0-9376-6850beda46de" />

<img width="1433" height="467" alt="image" src="https://github.com/user-attachments/assets/ccb397b0-d72f-4489-9aed-fc6b4d7d90f6" />

