### PR TITLE
chore: remove main branch check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,6 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Check tag is on main branch
-        run: |
-          BRANCH=$(git branch -r --contains ${{ github.ref_name }} | grep -E '^\s*origin/main$' || true)
-          if [ -z "$BRANCH" ]; then
-            echo "Tag ${{ github.ref_name }} is not on main branch, skipping release"
-            exit 1
-          fi
       - name: Get Go version from go.mod file
         id: go-version
         run: echo "version=$(go mod edit -json | jq -r .Go)" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
# What does this PR do?

Remove main branch check from release

# Motivation

since v4.0.0, actions/checkout only checks out the specific ref fetched, in our case the tag from which we're building a release.

as a consequence, it doesn't fetch the main branch, and does not know on which ref origin/main is. this is making the check tag step fail consistently.

since the release workflow is only triggered on tag push, remove the check to fix the issue.

See https://github.com/DataDog/dd-otel-host-profiler/actions/runs/17068728077/job/48392980661 for an example

# Additional Notes

N/A

# How to test the change?

Will test by pushing a release tag.
