### PR TITLE
feat(reporter): default service to Comm

### DIFF
--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -452,25 +452,25 @@ func (r *DatadogReporter) addProcessMetadata(trace *libpf.Trace, meta *samples.T
 	}
 
 	inferredService := false
-	if service == "" && execPath != "" {
+	switch {
+	case service != "":
+		// containerd shim injects an OTEL_SERVICE_NAME environment variable that contains a hash of the container ID
+		// see https://github.com/containerd/containerd/blob/1ce8e1ca0e43ae5942c6b60906b653107c442ce9/cmd/containerd-shim-runc-v2/manager/manager_linux.go#L106
+		// to avoid polluting the interface with multiple service names, we replace it with "containerd-shim"
+		if strings.HasPrefix(service, "containerd-shim-") {
+			service = "containerd-shim"
+		}
+	case execPath != "":
 		service = path.Base(execPath)
 		inferredService = true
-	}
-
-	if service == "" && rsamples.IsKernel(trace.Frames) {
+	case rsamples.IsKernel(trace.Frames):
 		service = "system"
-	}
-
-	if service == "" {
+	case meta.Comm != "":
+		service = meta.Comm
+		inferredService = true
+	default:
 		service = unknownServiceStr
 		inferredService = true
-	}
-
-	// containerd shim injects an OTEL_SERVICE_NAME environment variable that contains a hash of the container ID
-	// see https://github.com/containerd/containerd/blob/1ce8e1ca0e43ae5942c6b60906b653107c442ce9/cmd/containerd-shim-runc-v2/manager/manager_linux.go#L106
-	// to avoid polluting the interface with multiple service names, we replace it with "containerd-shim"
-	if strings.HasPrefix(service, "containerd-shim-") {
-		service = "containerd-shim"
 	}
 
 	var containerMetadata containermetadata.ContainerMetadata


### PR DESCRIPTION
while looking at profiles, there seems to be a lot of very-short lived processes from cilium, ctr, or crictl, for which traces contain a valid Comm (since it is set as the profile root frame), but service is not detected.

default the service name to `Comm` to further increase the number of process for which the service is successfully detected. in theory, comm should always be equivalent to path.Base(execPath).

# What does this PR do?

A brief description of the change being made with this pull request.

# Motivation

What inspired you to submit this pull request?  In order to motivate your point, it may be valuable to explain why this change is useful or what problem is being solved.

# Additional Notes

This is the section to put technical guidance/constraints, call out potential regressions, cite sources, and in general offer some exposition on the _how_ of the PR.  This section doesn't need to be incredibly detailed, but it makes life easier for reviewers!

# How to test the change?

Describe here in detail how the change can be validated.  This is a great section to call out specific tests you've added or improved, or to acknowledge code sections which are particularly difficult to test.
