### PR TITLE
fix(reporter): send empty build ID for dummy mappings

### DIFF
--- a/reporter/pprof/profile_builder.go
+++ b/reporter/pprof/profile_builder.go
@@ -194,7 +194,7 @@ func (b *ProfileBuilder) getDummyMapping() *pprofile.Mapping {
 		return tmpMapping
 	}
 
-	mapping := b.createPprofMapping("DUMMY", dummyFileID.StringNoQuotes())
+	mapping := b.createPprofMapping("DUMMY", "")
 	b.fileIDtoMapping[dummyFileID] = mapping
 
 	return mapping


### PR DESCRIPTION
# What does this PR do?

set an empty build ID for dummy mappings

# Motivation

clearly indicate that these frames do not need to be symbolicated

# Additional Notes

N/A

# How to test the change?

Tested locally