### PR TITLE
fix(reporter): trim (deleted) suffix from executable path

### DIFF
--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -423,6 +423,9 @@ func (r *DatadogReporter) addProcessMetadata(trace *libpf.Trace, meta *samples.T
 		log.Debugf("Failed to get process metadata for PID %d: %v", pid, err)
 		execPath = meta.ExecutablePath
 	}
+	// Trim the "(deleted)" suffix if it exists.
+	// This can happen when the executable has been deleted or replaced while the process is running.
+	execPath = strings.TrimSuffix(execPath, " (deleted)")
 
 	var processName string
 	if name, err2 := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid)); err2 == nil {


### PR DESCRIPTION
# What does this PR do?

Trim ` (deleted)` suffix from executable path

# Motivation

if the file was deleted, the path we get might contain a (deleted) suffix which can be confusing for users, as we'd show it both in:
- the service name (will be foo_deleted)
- the root frame (will be foo (deleted))

this commit strips the (deleted) suffix from the executable path

# Additional Notes

<img width="733" height="160" alt="image" src="https://github.com/user-attachments/assets/c2e081da-ce8d-42be-8be5-b2ed144b3ba7" />

<img width="1429" height="63" alt="image" src="https://github.com/user-attachments/assets/9d43df45-9937-4ba4-8c4f-dabb50fe9402" />


# How to test the change?

Tested locally as seen above.
