### PR TITLE
fix(reporter): set function name to UNKNOWN when empty

### DIFF
--- a/reporter/pprof/profile_builder.go
+++ b/reporter/pprof/profile_builder.go
@@ -90,10 +90,14 @@ func (b *ProfileBuilder) AddEvents(events samples.KeyToEventMapping) {
 				// that are not originate from a native or interpreted
 				// program.
 			default:
+				functionName := frame.FunctionName.String()
+				if functionName == "" {
+					functionName = unknownStr
+				}
 				// Store interpreted frame information as Line message:
 				line := pprofile.Line{
 					Line:     int64(frame.SourceLine),
-					Function: b.createPprofFunctionEntry(frame.FunctionName.String(), frame.SourceFile.String()),
+					Function: b.createPprofFunctionEntry(functionName, frame.SourceFile.String()),
 				}
 
 				loc.Line = append(loc.Line, line)


### PR DESCRIPTION
# What does this PR do?

in case we encounter unsymbolized kernel frames, this allows showing "UNKNOWN"

otherwise, the backend will show "Unknown Function (DUMMY)" which can be confusing for users

# Motivation

Before:
<img width="1429" height="381" alt="image" src="https://github.com/user-attachments/assets/dd252314-9c7e-4851-bebd-374c5798d2d7" />

After:

<img width="710" height="222" alt="image" src="https://github.com/user-attachments/assets/e1352f81-0473-4886-8c5f-5c4ca16e5858" />

# Additional Notes

N/A

# How to test the change?

Tested locally per screenshots above
