### PR TITLE
reporter: various metadata fixes

### DIFF
--- a/reporter/datadog_reporter.go
+++ b/reporter/datadog_reporter.go
@@ -468,6 +468,9 @@ func (r *DatadogReporter) addProcessMetadata(trace *libpf.Trace, meta *samples.T
 		inferredService = true
 	case rsamples.IsKernel(trace.Frames):
 		service = "system"
+	case processName != "":
+		service = processName
+		inferredService = true
 	case meta.Comm != "":
 		service = meta.Comm
 		inferredService = true


### PR DESCRIPTION
# What does this PR do?

* trim whitespace from metadata (process name, service name, executable path)
* default service name to process comm. we still prefer getting it from the executable path since process and thread comm are limited to 15 bytes.

# Motivation

small metadata fixes to improve metadata detection

# Additional Notes

N/A

# How to test the change?

N/A
