### PR TITLE
Rename 'dev' version to 'main'

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Determine versions
     runs-on: ubuntu-24.04
     env:
-      RELEASE_VERSION: ${{ (github.ref_name == 'main' && 'dev') || (github.event_name != 'pull_request' && github.ref_name) || github.head_ref }}    
+      RELEASE_VERSION: ${{ (github.ref_name == 'main' && 'main') || (github.event_name != 'pull_request' && github.ref_name) || github.head_ref }}    
     outputs:
       go-version: ${{ steps.go-version.outputs.version }}
       profiler-version: ${{ steps.profiler-version.outputs.version }}
@@ -47,7 +47,7 @@ jobs:
 
   publish:
     env:
-      RELEASE_VERSION: ${{ github.event_name == 'pull_request' && 'dev-test' || 'dev' }}
+      RELEASE_VERSION: ${{ github.event_name == 'pull_request' && 'dev-test' || 'main' }}
     if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'publish-dev-test') )}}
     name: Publish pre-release
     needs: [build]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ prepare_release_tag:
   stage: deploy
   tags: ["arch:amd64"]
   rules:
-    - if: $CI_COMMIT_TAG =~ /^gitlab-(v\d+\.\d+\.\d+(-rc\d+)?|dev|dev-test)$/
+    - if: $CI_COMMIT_TAG =~ /^gitlab-(v\d+\.\d+\.\d+(-rc\d+)?|main|dev-test)$/
       when: on_success
     - when: manual
       allow_failure: true


### PR DESCRIPTION
# What does this PR do?

Use `main` as the name for the version built from main, this makes it more consistent with relenv configuration name.