### PR TITLE
Update go version to 1.24.6

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4-bookworm@sha256:ee7ff13d239350cc9b962c1bf371a60f3c32ee00eaaf0d0f0489713a87e51a67
+FROM golang:1.24.6-bookworm@sha256:e617461712dbebf8768e10c1a5deab2833d67d2b692894cb8f4f0a3c19a8efb5
 
 RUN cross_debian_arch=$(uname -m | sed -e 's/aarch64/amd64/'  -e 's/x86_64/arm64/'); \
     cross_pkg_arch=$(uname -m | sed -e 's/aarch64/x86-64/' -e 's/x86_64/aarch64/'); \
@@ -8,9 +8,10 @@ RUN cross_debian_arch=$(uname -m | sed -e 's/aarch64/amd64/'  -e 's/x86_64/arm64
         curl wget make git cmake unzip libc6-dev g++ gcc pkgconf \
         gcc-${cross_pkg_arch}-linux-gnu libc6-${cross_debian_arch}-cross \
         musl-dev:amd64 musl-dev:arm64 && \
+    curl -sSf https://apt.llvm.org/llvm.sh | bash -s -- 17 && \
+    apt-get install -y clang-format-17 && \
     apt-get clean autoclean && \
-    apt-get autoremove --yes && \
-    curl -sSf https://apt.llvm.org/llvm.sh | bash -s -- 17
+    apt-get autoremove --yes
 
 RUN useradd -ms /bin/bash build
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/docker/dev/entrypoint.sh
+++ b/docker/dev/entrypoint.sh
@@ -1,13 +1,10 @@
 #! /usr/bin/env sh
-set -e
 
 DD_API_KEY="$(sudo cat /run/secrets/dd-api-key)"
 DD_APP_KEY="$(sudo cat /run/secrets/dd-app-key)"
 export DD_API_KEY DD_APP_KEY
 
-if [ ! -d /sys/kernel/debug/tracing ]; then
-    sudo mount -t debugfs none /sys/kernel/debug
-fi
+sudo test -d /sys/kernel/debug/tracing || sudo mount -t debugfs none /sys/kernel/debug
 
 cd /app/dd-otel-host-profiler
 exec "$@"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/dd-otel-host-profiler
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/DataDog/dd-trace-go/v2 v2.2.2


### PR DESCRIPTION
# What does this PR do?

Update go version to 1.24.6
Fix check for already mounted debugfs (needs to be done with root).
