### PR TITLE
fix: do not emit Lines for native frames

### DIFF
--- a/reporter/pprof/profile_builder.go
+++ b/reporter/pprof/profile_builder.go
@@ -82,7 +82,6 @@ func (b *ProfileBuilder) AddEvents(events samples.KeyToEventMapping) {
 				// As native frames are resolved in the backend, we use Mapping to
 				// report these frames.
 				loc.Mapping = b.createPprofMappingForFileID(frame.FileID)
-				loc.Line = append(loc.Line, pprofile.Line{Function: b.createPprofFunctionEntry("", loc.Mapping.File)})
 			case libpf.AbortFrame:
 				// Next step: Figure out how the OTLP protocol
 				// could handle artificial frames, like AbortFrame,


### PR DESCRIPTION
# What does this PR do?

Instead of adding a Line with an empty Function, we now emit no Line objects for native frames.

# Motivation

Allow simpler and more consistent code on backend side.