### PR TITLE
fix: sample count was always 1

### DIFF
--- a/reporter/pprof/profile_builder.go
+++ b/reporter/pprof/profile_builder.go
@@ -130,7 +130,7 @@ func (b *ProfileBuilder) AddEvents(events samples.KeyToEventMapping) {
 		}
 
 		var count int64 = 1
-		if b.timeline {
+		if !b.timeline {
 			count = int64(len(traceInfo.Timestamps))
 		}
 


### PR DESCRIPTION
# What does this PR do?

Logic for sample count was reversed, it should be:
* `len(traceInfo.Timestamps)` when timeline is disabled (default)
* 1 when timeline is enabled
