### PR TITLE
fix: remove duplicate variable traceHandlerIntervals

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -337,8 +337,7 @@ func Run(mainCtx context.Context, c *config.Config) ExitCode {
 	// change this log line update also the system test.
 	log.Printf("Attached sched monitor")
 
-	traceHandlerIntervals := times.New(c.ReporterInterval, 60*time.Second, c.ProbabilisticInterval)
-	if err := startTraceHandling(mainCtx, rep, traceHandlerIntervals, trc, traceHandlerCacheSize); err != nil {
+	if err := startTraceHandling(mainCtx, rep, intervals, trc, traceHandlerCacheSize); err != nil {
 		return failure("Failed to start trace handling: %v", err)
 	}
 


### PR DESCRIPTION
# What does this PR do?

MonitorInterval was hardcoded to a different value (60s) than the one used in the tracer (5s). But it was used only for metric reporting interval in the trace handler.
