### PR TITLE
[OTAGENT-564] Make SymbolUploaderConfig logic usable from datadog-agent repository

### DIFF
--- a/config/cli_flags.go
+++ b/config/cli_flags.go
@@ -45,9 +45,15 @@ const (
 	defaultClockSyncInterval      = 3 * time.Minute
 	defaultProbabilisticThreshold = tracer.ProbabilisticThresholdMax
 	defaultProbabilisticInterval  = 1 * time.Minute
-	defaultSymbolQueryInterval    = 5 * time.Second
 	defaultArgSendErrorFrames     = false
 	defaultArgAgentURL            = "http://localhost:8126"
+
+	DefaultSymbolQueryInterval  = 5 * time.Second
+	DefaultUploadSymbolsDryRun  = false
+	DefaultUploadSymbolsHTTP2   = false
+	DefaultUploadSymbols        = true
+	DefaultUploadDynamicSymbols = false
+	DefaultUploadGoPCLnTab      = true
 
 	// This is the X in 2^(n + x) where n is the default hardcoded map size value
 	defaultArgMapScaleFactor = 0
@@ -238,7 +244,7 @@ func parseCLIArgs(osArgs []string) (*Arguments, error) {
 			},
 			&cli.BoolFlag{
 				Name:        "upload-symbols",
-				Value:       true,
+				Value:       DefaultUploadSymbols,
 				Usage:       "Enable local symbol upload.",
 				Hidden:      true,
 				Destination: &args.UploadSymbols,
@@ -247,7 +253,7 @@ func parseCLIArgs(osArgs []string) (*Arguments, error) {
 			&cli.BoolFlag{
 				Name:        "upload-dynamic-symbols",
 				Usage:       "Enable dynamic symbols upload.",
-				Value:       false,
+				Value:       DefaultUploadDynamicSymbols,
 				Hidden:      true,
 				Sources:     cli.EnvVars("DD_HOST_PROFILING_UPLOAD_DYNAMIC_SYMBOLS"),
 				Destination: &args.UploadDynamicSymbols,
@@ -255,14 +261,14 @@ func parseCLIArgs(osArgs []string) (*Arguments, error) {
 			&cli.BoolFlag{
 				Name:        "upload-gopclntab",
 				Usage:       "Enable gopcnltab upload.",
-				Value:       true,
+				Value:       DefaultUploadGoPCLnTab,
 				Hidden:      true,
 				Sources:     cli.EnvVars("DD_HOST_PROFILING_UPLOAD_GOPCLNTAB"),
 				Destination: &args.UploadGoPCLnTab,
 			},
 			&cli.BoolFlag{
 				Name:        "upload-symbols-dry-run",
-				Value:       false,
+				Value:       DefaultUploadSymbolsDryRun,
 				Usage:       "Local symbol upload dry-run.",
 				Hidden:      true,
 				Destination: &args.UploadSymbolsDryRun,
@@ -332,7 +338,7 @@ func parseCLIArgs(osArgs []string) (*Arguments, error) {
 			},
 			&cli.DurationFlag{
 				Name:        "symbol-query-interval",
-				Value:       defaultSymbolQueryInterval,
+				Value:       DefaultSymbolQueryInterval,
 				Hidden:      true,
 				Usage:       "Symbol query interval (queries during a period are batched, 0 means no batching).",
 				Destination: &args.UploadSymbolQueryInterval,
@@ -354,7 +360,7 @@ func parseCLIArgs(osArgs []string) (*Arguments, error) {
 			},
 			&cli.BoolFlag{
 				Name:        "upload-symbols-http2",
-				Value:       false, // HTTP/2 is disabled by default, since support in the backend is recent
+				Value:       DefaultUploadSymbolsHTTP2, // HTTP/2 is disabled by default, since support in the backend is recent
 				Hidden:      true,
 				Usage:       "Use HTTP/2 when available for symbol upload. Only used if upload-symbols is enabled.",
 				Destination: &args.UploadSymbolsHTTP2,

--- a/reporter/config.go
+++ b/reporter/config.go
@@ -58,23 +58,32 @@ type Config struct {
 	SymbolUploaderConfig SymbolUploaderConfig
 }
 
-type SymbolUploaderConfig struct {
+type SymbolUploaderOptions struct {
 	// Enabled defines whether the agent should upload debug symbols to the backend.
-	Enabled bool
+	Enabled bool `mapstructure:"enabled"`
 	// UploadDynamicSymbols defines whether the agent should upload dynamic symbols to the backend.
-	UploadDynamicSymbols bool
+	UploadDynamicSymbols bool `mapstructure:"upload_dynamic_symbols"`
 	// UploadGoPCLnTab defines whether the agent should upload GoPCLnTab section for Go binaries to the backend.
-	UploadGoPCLnTab bool
+	UploadGoPCLnTab bool `mapstructure:"upload_go_pcln_tab"`
 	// UseHTTP2 defines whether the agent should use HTTP/2 when uploading symbols.
-	UseHTTP2 bool
+	UseHTTP2 bool `mapstructure:"use_http2"`
 	// SymbolQueryInterval defines the interval at which the agent should query the backend for symbols. A value of 0 disables batching.
-	SymbolQueryInterval time.Duration
-	// DisableDebugSectionCompression defines whether the uploader should disable debug section compression whatever objcopy supports.
-	DisableDebugSectionCompression bool
+	SymbolQueryInterval time.Duration `mapstructure:"symbol_query_interval"`
 	// DryRun defines whether the agent should upload debug symbols to the backend in dry-run mode.
-	DryRun bool
+	DryRun bool `mapstructure:"dry_run"`
 	// Sites to upload symbols to.
-	SymbolEndpoints []SymbolEndpoint
+	SymbolEndpoints []SymbolEndpoint `mapstructure:"symbol_endpoints"`
+
+	// IMPORTANT NOTE: If you add a new option, you must update the code in datadog-agent repository as well to use the same default value.
+	// See https://github.com/DataDog/datadog-agent/pull/41475/files#diff-609e6520a7c28e0fce4caeea5197a3dc3e54fde00e3f2b43cdd6bceaa664098b
+}
+
+type SymbolUploaderConfig struct {
+	// Options defines the options for the symbol uploader.
+	SymbolUploaderOptions
+	// DisableDebugSectionCompression defines whether the uploader should disable debug section compression whatever objcopy supports.
+	// This is only used for testing purposes.
+	DisableDebugSectionCompression bool
 	// Version is the version of the profiler.
 	Version string
 }

--- a/reporter/symbol_uploader_test.go
+++ b/reporter/symbol_uploader_test.go
@@ -298,11 +298,13 @@ func newTestUploader(opts uploaderOpts) (*DatadogSymbolUploader, error) {
 	}
 
 	cfg := &SymbolUploaderConfig{
-		Enabled:                        true,
-		UploadDynamicSymbols:           opts.uploadDynamicSymbols,
-		UploadGoPCLnTab:                opts.uploadGoPCLnTab,
-		SymbolQueryInterval:            0,
-		SymbolEndpoints:                endpoints,
+		SymbolUploaderOptions: SymbolUploaderOptions{
+			Enabled:              true,
+			UploadDynamicSymbols: opts.uploadDynamicSymbols,
+			UploadGoPCLnTab:      opts.uploadGoPCLnTab,
+			SymbolQueryInterval:  0,
+			SymbolEndpoints:      endpoints,
+		},
 		DisableDebugSectionCompression: opts.disableDebugSectionCompression,
 	}
 	return NewDatadogSymbolUploader(cfg)
@@ -560,10 +562,12 @@ func TestSymbolUpload(t *testing.T) {
 // when HTTP/2 is disabled
 func TestTransport(t *testing.T) {
 	cfg := &SymbolUploaderConfig{
-		Enabled:         true,
-		UseHTTP2:        false, // This forces creation of custom transport
-		SymbolEndpoints: []SymbolEndpoint{{Site: "test.com", APIKey: "key", AppKey: "app"}},
-		Version:         "test",
+		SymbolUploaderOptions: SymbolUploaderOptions{
+			Enabled:         true,
+			UseHTTP2:        false, // This forces creation of custom transport
+			SymbolEndpoints: []SymbolEndpoint{{Site: "test.com", APIKey: "key", AppKey: "app"}},
+		},
+		Version: "test",
 	}
 
 	uploader, err := NewDatadogSymbolUploader(cfg)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -252,14 +252,16 @@ func Run(mainCtx context.Context, c *config.Config) ExitCode {
 		CollectContext:                       c.CollectContext,
 		KernelSupportsNamedAnonymousMappings: kernelSupportsNamedAnonymousMappings(kernVersion),
 		SymbolUploaderConfig: reporter.SymbolUploaderConfig{
-			Enabled:              c.UploadSymbols,
-			UploadDynamicSymbols: c.UploadDynamicSymbols,
-			UploadGoPCLnTab:      c.UploadGoPCLnTab,
-			UseHTTP2:             c.UploadSymbolsHTTP2,
-			SymbolQueryInterval:  c.UploadSymbolQueryInterval,
-			DryRun:               c.UploadSymbolsDryRun,
-			SymbolEndpoints:      validSymbolEndpoints,
-			Version:              versionInfo.Version,
+			SymbolUploaderOptions: reporter.SymbolUploaderOptions{
+				Enabled:              c.UploadSymbols,
+				UploadDynamicSymbols: c.UploadDynamicSymbols,
+				UploadGoPCLnTab:      c.UploadGoPCLnTab,
+				UseHTTP2:             c.UploadSymbolsHTTP2,
+				SymbolQueryInterval:  c.UploadSymbolQueryInterval,
+				DryRun:               c.UploadSymbolsDryRun,
+				SymbolEndpoints:      validSymbolEndpoints,
+			},
+			Version: versionInfo.Version,
 		},
 	}, containerMetadataProvider)
 	if err != nil {


### PR DESCRIPTION
# What does this PR do?

This PR exports some of the SymbolUploaderConfig logic so that the host-profiler collector in the datadog-agent repository can reuse the same implementation.

# Motivation

If the SymbolUploaderConfig logic changes, there is no need to manually backport those changes to the datadog-agent repository.

# Additional Notes

The code exported in this PR will eventually be moved into the datadog-agent repository.

# How to test the change?

Run this code from the datadog-agent repository.
